### PR TITLE
Fix #21

### DIFF
--- a/sphinx_immaterial/apidoc_formatting.py
+++ b/sphinx_immaterial/apidoc_formatting.py
@@ -182,7 +182,7 @@ def _monkey_patch_python_get_signature_prefix(
 
     def get_signature_prefix(self, sig: str) -> str:
         prefix = orig_get_signature_prefix(self, sig)
-        if sphinx.version_info[0] >= 4 and sphinx.version_info[1] >= 3:
+        if sphinx.version_info >= (4, 3):
             return prefix
         parts = prefix.strip().split(" ")
         if "property" in parts:

--- a/sphinx_immaterial/apidoc_formatting.py
+++ b/sphinx_immaterial/apidoc_formatting.py
@@ -182,6 +182,8 @@ def _monkey_patch_python_get_signature_prefix(
 
     def get_signature_prefix(self, sig: str) -> str:
         prefix = orig_get_signature_prefix(self, sig)
+        if sphinx.version_info[0] >= 4 and sphinx.version_info[1] >= 3:
+            return prefix
         parts = prefix.strip().split(" ")
         if "property" in parts:
             parts.remove("property")

--- a/sphinx_immaterial/search_adapt.py
+++ b/sphinx_immaterial/search_adapt.py
@@ -10,7 +10,7 @@
 """
 
 import io
-from typing import Any, Dict, IO, List, Tuple
+from typing import Any, Dict, IO, List, Tuple, Union
 
 import sphinx.search
 import sphinx.application
@@ -19,7 +19,14 @@ import sphinx.application
 class IndexBuilder(sphinx.search.IndexBuilder):
     def get_objects(
         self, fn2index: Dict[str, int]
-    ) -> Dict[str, List[Tuple[int, int, int, str, str]]]:
+    ) -> Dict[
+        str,
+        Union[
+            # From sphinx 4.3 onwards the children dict is now a list
+            Dict[str, Tuple[int, int, int, str]],
+            List[Tuple[int, int, int, str, str]],
+        ],
+    ]:
         rv = super().get_objects(fn2index)
         onames = self._objnames
         for prefix in rv:
@@ -27,7 +34,7 @@ class IndexBuilder(sphinx.search.IndexBuilder):
                 name_prefix = prefix + "."
             else:
                 name_prefix = ""
-            if sphinx.version_info[0] >= 4 and sphinx.version_info[1] >= 3:
+            if sphinx.version_info >= (4, 3):
                 # From sphinx 4.3 onwards the children dict is now a list
                 children = rv[prefix]
             else:
@@ -46,7 +53,7 @@ class IndexBuilder(sphinx.search.IndexBuilder):
                     synopsis = get_object_synopsis(objtype, full_name)
                     if synopsis:
                         synopsis = synopsis.strip()
-                if sphinx.version_info[0] >= 4 and sphinx.version_info[1] >= 3:
+                if sphinx.version_info >= (4, 3):
                     rv[prefix][i] = (
                         docindex,
                         typeindex,


### PR DESCRIPTION
This PR aims to fix #21 in a backwards compatible way.

It 

* updates the index builder to handle either a dict or list of children
* updates the api doc signature patch to handle a list of nodes rather than a list of strings.

@jbms I wasn't sure why the api doc patch is removing properties from the parts list, and this line doesn't seem to be hit when building the example docs in the repo. Any ideas if we need it? 

For now I just return the output of the original function and that seems to yield docs that look identical.