### PR TITLE
Prevent navigation tabs linking to subsection

### DIFF
--- a/src/partials/tabs-item.html
+++ b/src/partials/tabs-item.html
@@ -29,7 +29,7 @@
 {% endif %}
 
 <!-- Main navigation item with nested items -->
-{% if nav_item.children %}
+{% if false %}
   {% set atitle = atitle | d(nav_item.title) %}
   {% set nav_item = nav_item.children | first %}
 


### PR DESCRIPTION
I know nearly no HTML/CSS, so forgive my n00bness.

After the discussed in #31, I tested changes locally with my project. I found the "Main navigation item with nested items" `if` statement doesn't need to run.

https://github.com/jbms/sphinx-immaterial/blob/1597b3e8c81ee2834a152ba77ba833d667f32e8a/src/partials/tabs-item.html#L31-L48

Only the `else` statement needs to run.

https://github.com/jbms/sphinx-immaterial/blob/1597b3e8c81ee2834a152ba77ba833d667f32e8a/src/partials/tabs-item.html#L49-L56

Instead of deleting the `if` statement, I just set it to `false` to minimize merge conflicts with upstream.