### PR TITLE
support `hide` metadata and update docs

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -130,9 +130,8 @@ Each metadata is evaluated as a ``:key: value`` pair.
 
 .. confval:: hide-navigation
 
-    If specified, hides the global navigation sidebar shown on the left side (or right side in
-    ``rtl`` languages `direction`) of the page. By default, the navigation menu is shown if the
-    browser viewport is sufficiently wide.
+    If specified, hides the global navigation sidebar shown on the left side of the page.
+    By default, the navigation menu is shown if the browser viewport is sufficiently wide.
 
     .. code-block:: rst
         :caption: Hide the navigation menu like so:
@@ -141,10 +140,10 @@ Each metadata is evaluated as a ``:key: value`` pair.
 
 .. confval:: hide-toc
 
-    If specified, hides the local table of contents shown on the right side (or left side in
-    ``rtl`` languages `direction`) of the page. By default the local table of contents is shown if
-    the page contains sub-sections and the browser viewport is sufficiently wide. If the
-    ``toc.integrate`` `feature <features>` is enabled, then this option has no effect.
+    If specified, hides the local table of contents shown on the right side of the page.
+    By default the local table of contents is shown if the page contains sub-sections and the
+    browser viewport is sufficiently wide. If the ``toc.integrate`` `feature <features>` is
+    enabled, then this option has no effect.
     
     .. code-block:: rst
         :caption: Hide the Table of Contents like so:

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -224,7 +224,7 @@ Configuration Options
 
         .. hint::
             Sphinx automatically implements the
-            `navigation.index <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#section-index-pages>`_
+            `navigation.indexes <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#section-index-pages>`_
             feature.
 
     .. confval:: palette

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -104,11 +104,16 @@
 Customization
 =============
 
-This theme is customized via fields in the `html_theme_options` `dict` in *conf.py*.
-Unlike, newer versions of mkdocs-material theme, this theme also supports the use of a textual
-"hero" section.
+Metadata for a single page
+==========================
+
+Each page can support a set of page-specific options. These are configured using metadata roles.
+Each metadata is evaluated as a ``:key: value`` pair.
 
 .. confval:: hero
+
+    Unlike, newer versions of mkdocs-material theme, this theme also supports the use of a textual
+    "hero" section.
 
     To set the hero's text for an individual page, use the ``:hero:`` metadata field for the desired page.
     If not specified, then the page will not have a hero section.
@@ -118,23 +123,33 @@ Unlike, newer versions of mkdocs-material theme, this theme also supports the us
 
         :hero: Configuration options to personalize your site.
 
-.. confval:: hide
+.. confval:: hide-navigation
 
-    Unlike the mkdocs-material theme, using the ``:hide:`` metadata can only be used to hide the
-    page's navigation menu (on large viewports only). This is done like so:
+    This theme uses the ``:hide-navigation:`` metadata to hide the page's navigation menu (on
+    large enough viewports only).
 
     .. code-block:: rst
+        :caption: Hide the navigation menu like so:
 
-        :hide: navigation
+        :hide-navigation:
 
-    .. note::
+.. confval:: hide-toc
 
-        Instead of using ``:hide: toc``, this theme uses the ``:tocdepth:`` metadata to hide the
-        page's Table of Contents.
+    This theme uses ``:hide-toc:`` metadata to hide the page's Table of Contents (on large enough
+    viewports only).
 
-        .. code-block:: rst
+    .. code-block:: rst
+        :caption: Hide the Table of Contents like so:
 
-            :tocdepth: 0
+        :hide-toc:
+
+    Instead of using ``:hide-toc:``, this theme can also use the ``:tocdepth:`` metadata to hide the
+    page's Table of Contents.
+
+    .. code-block:: rst
+        :caption: Set the depth for the Table of Contents to ``0``:
+
+        :tocdepth: 0
 
 Configuration Options
 =====================
@@ -151,6 +166,10 @@ Configuration Options
         and `html_favicon` are not as strict for this theme.
 
 .. confval:: html_theme_options
+
+    This theme is configured using a ``html_theme_options`` `dict` in the *conf.py* file. The
+    following subsections can be used can be used as keys whose values configure the theme in
+    different ways.
 
     .. confval:: site_url
 

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -118,6 +118,24 @@ Unlike, newer versions of mkdocs-material theme, this theme also supports the us
 
         :hero: Configuration options to personalize your site.
 
+.. confval:: hide
+
+    Unlike the mkdocs-material theme, using the ``:hide:`` metadata can only be used to hide the
+    page's navigation menu (on large viewports only). This is done like so:
+
+    .. code-block:: rst
+
+        :hide: navigation
+
+    .. note::
+
+        Instead of using ``:hide: toc``, this theme uses the ``:tocdepth:`` metadata to hide the
+        page's Table of Contents.
+
+        .. code-block:: rst
+
+            :tocdepth: 0
+
 Configuration Options
 =====================
 
@@ -128,7 +146,9 @@ Configuration Options
 
     .. seealso::
         This option is documented with more detail in the Sphinx documentation.
-        However, the size contrants for `html_logo` and `html_favicon` are not as strict for this theme.
+        However, the size constraints for
+        `html_logo <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_logo>`_
+        and `html_favicon` are not as strict for this theme.
 
 .. confval:: html_theme_options
 
@@ -193,13 +213,19 @@ Configuration Options
         - `navigation.expand <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-expansion>`_
         - `navigation.instant <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading>`_
         - `navigation.sections <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-sections>`_
-        - `navigation.tabs <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-tabs>`_ (only shows for browsers with large viewports)
+        - `navigation.tabs <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-tabs>`_
+          (only shows for browsers with large viewports)
         - `navigation.tabs.sticky <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#sticky-navigation-tabs>`_
         - `navigation.top <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#back-to-top-button>`_
         - `navigation.tracking <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#anchor-tracking>`_
         - `search.highlight <https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#search-highlighting>`_
         - `search.share <https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#search-sharing>`_
         - `toc.integrate <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-integration>`_
+
+        .. hint::
+            Sphinx automatically implements the
+            `navigation.index <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#section-index-pages>`_
+            feature.
 
     .. confval:: palette
 

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -110,6 +110,11 @@ Metadata for a single page
 Each page can support a set of page-specific options. These are configured using metadata roles.
 Each metadata is evaluated as a ``:key: value`` pair.
 
+.. seealso::
+    Review the
+    `File-wide metadata <https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html#file-wide-metadata>`_
+    section in the sphinx docs.
+
 .. confval:: hero
 
     Unlike, newer versions of mkdocs-material theme, this theme also supports the use of a textual
@@ -125,8 +130,9 @@ Each metadata is evaluated as a ``:key: value`` pair.
 
 .. confval:: hide-navigation
 
-    This theme uses the ``:hide-navigation:`` metadata to hide the page's navigation menu (on
-    large enough viewports only).
+    If specified, hides the global navigation sidebar shown on the left side (or right side in
+    ``rtl`` languages `direction`) of the page. By default, the navigation menu is shown if the
+    browser viewport is sufficiently wide.
 
     .. code-block:: rst
         :caption: Hide the navigation menu like so:
@@ -135,9 +141,11 @@ Each metadata is evaluated as a ``:key: value`` pair.
 
 .. confval:: hide-toc
 
-    This theme uses ``:hide-toc:`` metadata to hide the page's Table of Contents (on large enough
-    viewports only).
-
+    If specified, hides the local table of contents shown on the right side (or left side in
+    ``rtl`` languages `direction`) of the page. By default the local table of contents is shown if
+    the page contains sub-sections and the browser viewport is sufficiently wide. If the
+    ``toc.integrate`` `feature <features>` is enabled, then this option has no effect.
+    
     .. code-block:: rst
         :caption: Hide the Table of Contents like so:
 
@@ -161,8 +169,7 @@ Configuration Options
 
     .. seealso::
         This option is documented with more detail in the Sphinx documentation.
-        However, the size constraints for
-        `html_logo <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_logo>`_
+        However, the size constraints for :external+sphinx_docs:confval:`html_logo`
         and `html_favicon` are not as strict for this theme.
 
 .. confval:: html_theme_options

--- a/sphinx_immaterial/nav_adapt.py
+++ b/sphinx_immaterial/nav_adapt.py
@@ -454,8 +454,11 @@ def _html_page_context(
         meta={"hide": [], "revision_date": context.get("last_updated")},
         content=context.get("body"),
     )
-    if meta and meta.get("tocdepth") == 0:
-        page["meta"]["hide"].append("toc")
+    if meta:
+        if meta.get("tocdepth") == 0:
+            page["meta"]["hide"].append("toc")
+        if meta.get("hide") == "navigation":
+            page["meta"]["hide"].append("navigation")
     if context.get("next"):
         page["next_page"] = {
             "title": jinja2.Markup.escape(

--- a/sphinx_immaterial/nav_adapt.py
+++ b/sphinx_immaterial/nav_adapt.py
@@ -455,9 +455,9 @@ def _html_page_context(
         content=context.get("body"),
     )
     if meta:
-        if meta.get("tocdepth") == 0:
+        if meta.get("tocdepth") == 0 or "hide-toc" in meta.keys():
             page["meta"]["hide"].append("toc")
-        if meta.get("hide") == "navigation":
+        if "hide-navigation" in meta.keys():
             page["meta"]["hide"].append("navigation")
     if context.get("next"):
         page["next_page"] = {


### PR DESCRIPTION
This resolves #39 and closes #37 

I updated the docs to guide users on how to hide a certain page's ToC and navigation menu. While I was updating customization.rst, I also added a hint about sphinx auto-implementing `navigation.indexes` feature from mkdocs-material.