### PR TITLE
Properly configure Google Analytics

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -372,9 +372,18 @@ Configuration Options
 
         You can specify any of the available `Google Fonts <https://fonts.google.com/>`_.
 
-    .. confval:: google_analytics_account
+    .. confval:: analytics
 
-        Set to enable google analytics.
+        Set to enable site analytics.
+
+        .. code-block:: python
+
+            html_theme_options = {
+                "analytics": {
+                    "provider": "google",
+                    "property": "G-XXXXXXXXXX"  # Or "UA-XXXXXXXX-X"
+                }
+            }
 
     .. confval:: globaltoc_collapse
 

--- a/sphinx_immaterial/__init__.py
+++ b/sphinx_immaterial/__init__.py
@@ -1,4 +1,4 @@
-"""Sphinx Material theme."""
+"""Sphinx-Immaterial theme."""
 
 import os
 from typing import List, Type, Dict, Mapping
@@ -227,10 +227,13 @@ def html_page_context(
 
     analytics = None
     if theme_options.get("google_analytics"):
+        # Parse old-style analytics config for backwards compatibility
         analytics = {
             "provider": "google",  # Google is the only provider currently supported
             "property": theme_options.get("google_analytics")[0],
         }
+    if theme_options.get("analytics"):
+        analytics = theme_options.get("analytics")
 
     context.update(
         config=dict_merge(

--- a/sphinx_immaterial/__init__.py
+++ b/sphinx_immaterial/__init__.py
@@ -229,7 +229,7 @@ def html_page_context(
     if theme_options.get("google_analytics"):
         analytics = {
             "provider": "google",  # Google is the only provider currently supported
-            "property": theme_options.get("google_analytics")[0]
+            "property": theme_options.get("google_analytics")[0],
         }
 
     context.update(

--- a/sphinx_immaterial/__init__.py
+++ b/sphinx_immaterial/__init__.py
@@ -225,6 +225,13 @@ def html_page_context(
             "versionPath": theme_options.get("version_json"),
         }
 
+    analytics = None
+    if theme_options.get("google_analytics"):
+        analytics = {
+            "provider": "google",  # Google is the only provider currently supported
+            "property": theme_options.get("google_analytics")[0]
+        }
+
     context.update(
         config=dict_merge(
             context.get("config", {}),
@@ -239,9 +246,9 @@ def html_page_context(
                     "social": theme_options.get("social"),
                     "disqus": theme_options.get("disqus"),
                     "manifest": theme_options.get("pwa_manifest"),
+                    "analytics": analytics,
                 },
                 "plugins": theme_options.get("plugins"),
-                "google_analytics": theme_options.get("google_analytics"),
             },
         ),
         base_url=base_url,


### PR DESCRIPTION
This PR fixes #48 by properly assigning the `config` dictionary with the Google Analytics property value.

After some digging, I realized the Material for Mkdocs analytics code (partial) was not being added during local testing. The Google Analytics signaling I get on RTD is from custom JS added by RTD at build time.

Below is the partial looking for `config.extra.analytics`, which currently is not set.

https://github.com/jbms/sphinx-immaterial/blob/3b1a1a097d2923c7cd8736eb6509a0aca7d96aba/src/partials/integrations/analytics/google.html#L23-L30

I learned that the `google_analytics` configuration option has been deprecated in favor of `extra/analytics`. See [here](https://squidfunk.github.io/mkdocs-material/upgrade/?h=google+ana#google_analytics).

### Current PR

This PR reads the old configuration style and assigns it properly in the `config` dictionary passed to the Material for Mkdocs pages. I tested this locally and it works -- the partial is added to the page and I can receive GA reports in my account, including search terms! 

```python
html_theme_options = {
    ...
    "google_analytics": ["G-XXXXXXXXXXXX", "auto"],
    ...
}
```

### Future PR

However, I think it would be wise to adjust the `html_theme_options` hierarchy to match Material for Mkdocs configuration hierarchy. That is, I believe the `html_theme_options` should be:

```python
html_theme_options = {
    ...
    "extra": {
        ...
        "analytics": {
            "provider": "google",
            "property": "G-XXXXXXXXXXX",
        }
        ...
    }
    ...
}
```

I noticed `"social"`, `"disqus"`, and `"pwa_manifest"` also don't have the property hierarchy. I believe they should be nested in the `"extra"` dictionary within `html_theme_options`.

https://github.com/jbms/sphinx-immaterial/blob/3b1a1a097d2923c7cd8736eb6509a0aca7d96aba/sphinx_immaterial/__init__.py#L228-L248

I'm willing to make this change and document it in a subsequent PR if you agree.