### PR TITLE
Add object description options mechanism

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,11 +1,112 @@
 General API customization
 =========================
 
-.. confval:: include_object_description_fields_in_toc
+This theme supports a number of options that can be customized for each
+domain/object type pair.
 
-   :python:`bool` indicating whether to include domain object description
-   fields, like "Parameters", "Returns", "Raises", etc. in the table of
-   contents.  Defaults to :python:`True`.
+.. confval:: object_description_options
+
+   :python:`list` of :python:`(pattern, options)` pairs, where :python:`pattern`
+   is a regular expression matching strings of the form
+   :python:`"domain:objtype"` and :python:`options` is a dictionary of supported
+   `object-description-options`.
+
+   We need something `object_description_options`.
+
+   The actual options for a given object type are determined by first
+   initializing each option to its default value, and then applying as overrides
+   the options associated with each matching pattern in order.
+
+.. _object-description-options:
+
+Object description options
+--------------------------
+
+The following options can be customized for each object type using
+:confval:`object_description_options`.
+
+.. objconf:: include_in_toc
+
+   Indicates whether to include the object description in the table of contents.
+
+   .. admonition:: Example
+      :class: example
+
+      To prevent C++ parameter descriptions from appearing in the TOC, add the
+      following to :file:`conf.py`:
+
+      .. code-block:: python
+
+         object_description_options = [
+             ("cpp:.*Param": dict(include_in_toc=False)),
+         ]
+
+.. objconf:: generate_synopses
+
+   Indicates whether to generate a *synopsis* from the object description.  The
+   synopsis is shown as a tooltip when hovering over a cross-reference link, and
+   is also shown in the search results list.  Supported values are:
+
+   :python:`None`
+     Disables synopsis generation.
+
+   :python:`"first_paragraph"`
+     Uses the first paragraph of the description as the synopsis.
+
+   :python:`"first_sentence"`
+     Uses the first sentence of the first paragraph of the description as the synopsis.
+
+   The default is :python:`"first_paragraph"` except for :regexp:`c(pp)?:.*Param`
+   where the default is :python:`"first_sentence"`.
+
+   .. note::
+
+      Synopsis generation is currently supported only for the following domains:
+
+      - ``std`` (including object types added using :py:obj:`sphinx.application.Sphinx.add_object_type`)
+      - ``c`` and ``cpp``
+
+   .. admonition:: Example
+      :class: example
+
+      To use the first sentence rather than the first paragraph as the synopsis
+      for C++ class descriptions, add the following to :file:`conf.py`:
+
+      .. code-block:: python
+
+         object_description_options = [
+             ("cpp:class", dict(generate_synopses="first_sentence")),
+         ]
+
+.. objconf:: include_object_type_in_xref_tooltip
+
+   Indicates whether to include the object type in cross-reference and TOC
+   tooltips.
+
+   .. note::
+
+      For TOC entries, this is supported for all domains.  For regular cross
+      references, this is supported only for the following domains:
+
+      - ``std`` (including object types added using :py:obj:`sphinx.application.Sphinx.add_object_type`)
+      - ``c`` and ``cpp``
+
+   .. admonition:: Example
+      :class: example
+
+      To exclude the object type from all ``py`` domain xrefs, add the following
+      to :file:`conf.py`:
+
+      .. code-block:: python
+
+         object_description_options = [
+             ("py:.*", dict(include_object_type_in_xref_tooltip=False)),
+         ]
+
+.. objconf:: include_fields_in_toc
+
+   Indicates whether to include fields, like "Parameters", "Returns", "Raises",
+   etc. in the table of contents.
 
    For an example, see: :cpp:expr:`synopses_ex::Foo` and note the ``Template
    Parameters``, ``Parameters``, and ``Returns`` headings shown in the
@@ -13,11 +114,73 @@ General API customization
 
    .. note::
 
-      This option does not control whether there are separate TOC entries for
-      individual parameters, such as for :cpp:expr:`synopses_ex::Foo::T`,
+      To control whether there are separate TOC entries for individual
+      parameters, such as for :cpp:expr:`synopses_ex::Foo::T`,
       :cpp:expr:`synopses_ex::Foo::N`, :cpp:expr:`synopses_ex::Foo::param`, and
-      :cpp:expr:`synopses_ex::Foo::arr`.  Currently, for the C and C++ domains,
-      any parameter documented by a :rst:``:param x:`` field will always result
-      in a TOC entry, regardless of the value of
-      :confval:`include_object_description_fields_in_toc`.  Other domains are
-      not yet supported.
+      :cpp:expr:`synopses_ex::Foo::arr`, use the :objconf:`include_in_toc`
+      option.
+
+
+   .. admonition:: Example
+      :class: example
+
+      To exclude object description fields from the table of contents for all
+      ``py`` domain objects, add the following to :file:`conf.py`:
+
+      .. code-block:: python
+
+         object_description_options = [
+             ("py:.*", dict(include_fields_in_toc=False)),
+         ]
+
+Other options described elsewhere include:
+
+- :objconf:`wrap_signatures_with_css`
+- :objconf:`wrap_signatures_column_limit`
+- :objconf:`clang_format_style`
+
+Table of contents icons
+^^^^^^^^^^^^^^^^^^^^^^^
+
+For object descriptions included in the table of contents (when
+:objconf:`include_in_toc` is :python:`True`), a text-based "icon" can optionally
+be included to indicate the object type.
+
+Default icons are specified for a number of object types, but they can be
+overridden using the following options:
+
+.. objconf:: toc_icon_class
+
+   Indicates the icon class, or :python:`None` to disable the icon.  The class
+   must be one of:
+
+   - :python:`"alias"`
+   - :python:`"procedure"`
+   - :python:`"data"`
+   - :python:`"sub-data"`
+
+.. objconf:: toc_icon_text
+
+   Indicates the text content of the icon, or :python:`None` to disable the
+   icon.  This should normally be a single character, such as :python:`"C"` to
+   indicate a class or :python:`"F"` to indicate a function.
+
+.. admonition:: Example
+   :class: example
+
+   To define a custom object type and specify an icon for it, add the following to
+   :file:`conf.py`:
+
+   .. code-block:: python
+
+      object_description_options = [
+          ("std:confval", dict(toc_icon_class="data", toc_icon_text="C")),
+      ]
+
+      def setup(app):
+          app.add_object_type(
+              "confval",
+              "confval",
+              objname="configuration value",
+              indextemplate="pair: %s; configuration value",
+          )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -239,6 +239,13 @@ object_description_options.append(
 )
 
 
+def _validate_parallel_build(app):
+    # Verifies that all of the extensions defined by this theme support parallel
+    # building.
+    assert app.is_parallel_allowed("read")
+    assert app.is_parallel_allowed("write")
+
+
 def _parse_object_description_signature(
     env: sphinx.environment.BuildEnvironment, signature: str, node: docutils.nodes.Node
 ) -> str:
@@ -279,4 +286,4 @@ def setup(app):
         indextemplate="pair: %s; object description option",
         parse_node=_parse_object_description_signature,
     )
-    return {"parallel_read_safe": True, "parallel_write_safe": True}
+    app.connect("builder-inited", _validate_parallel_build)

--- a/docs/cpp.rst
+++ b/docs/cpp.rst
@@ -1,59 +1,6 @@
 C++ domain customization
 ========================
 
-.. confval:: cpp_generate_synopses
-
-   :python:`bool` specifying whether to generate a *synopsis* for C++ domain
-   objects based on the first paragraph of their content (first sentence for
-   parameters).  The synopsis is shown as a tooltip when hovering over a
-   cross-reference link, and is also shown in the search results list.
-
-   Defaults to :python:`True`.
-
-   .. rst-example:: C++ synopses
-
-      .. cpp:type:: synopses_ex::SomeType
-
-         Description will be shown as a tooltip when hovering over
-         cross-references to :cpp:expr:`SomeType` in other signatures as well as
-         in the TOC.
-
-         Additional description not shown in tooltip.  This is the return type
-         for :cpp:expr:`Foo`.
-
-      .. cpp:function:: template <typename T, int N> \
-                        synopses_ex::SomeType synopses_ex::Foo(\
-                          T param, \
-                          const int (&arr)[N]\
-                        );
-
-         Synopsis for this function, shown when hovering over cross references
-         as well as in the TOC.
-
-         :tparam T: Tooltip shown when hovering over cross-references to this
-             template parameter.  Additional description not included in
-             tooltip.
-         :tparam N: Tooltip shown for N.
-         :param param: Tooltip shown for cross-references to this function
-             parameter param.
-         :param arr: Tooltip shown for cross-references to this function
-             parameter arr.  To cross reference another parameter, use the
-             :rst:role:`cpp:expr` role, e.g.: :cpp:expr:`N`.  Parameters can
-             also be referenced via their fake qualified name,
-             e.g. :cpp:expr:`synopses_ex::Foo::N`.
-         :returns: Something or other.
-
-
-   .. rst-example::
-
-      .. cpp:class:: synopses_ex::Class
-
-          .. cpp:function:: Class(uint16_t _cepin, uint16_t _cspin, uint32_t _spi_speed=RF24_SPI_SPEED)
-
-              :param _cepin: The pin attached to Chip Enable on the RF module
-              :param _cspin: The pin attached to Chip Select (often labeled CSN) on the radio module.
-              :param _spi_speed: The SPI speed in Hz ie: 1000000 == 1Mhz
-
 .. confval:: cpp_strip_namespaces_from_signatures
 
    :python:`list[str]` specifying namespaces to strip from signatures.  This

--- a/docs/demo_api.rst
+++ b/docs/demo_api.rst
@@ -47,7 +47,7 @@ C++ API
       :param len: Length of :cpp:expr:`arr`.
       :param baz: Baz parameter.
 
-.. rst-example::
+.. rst-example:: Cross-linking of macro parameters.
 
    .. c:macro:: MY_MACRO(X, Y, Z)
 
@@ -101,6 +101,49 @@ C++ API
       A scoped enum with non-default visibility, and with a specified underlying type.
 
       .. cpp:enumerator:: B
+
+.. rst-example:: C++ synopses
+
+   .. cpp:type:: synopses_ex::SomeType
+
+      Description will be shown as a tooltip when hovering over
+      cross-references to :cpp:expr:`SomeType` in other signatures as well as
+      in the TOC.
+
+      Additional description not shown in tooltip.  This is the return type
+      for :cpp:expr:`Foo`.
+
+   .. cpp:function:: template <typename T, int N> \
+                     synopses_ex::SomeType synopses_ex::Foo(\
+                       T param, \
+                       const int (&arr)[N]\
+                     );
+
+      Synopsis for this function, shown when hovering over cross references
+      as well as in the TOC.
+
+      :tparam T: Tooltip shown when hovering over cross-references to this
+          template parameter.  Additional description not included in
+          tooltip.
+      :tparam N: Tooltip shown for N.
+      :param param: Tooltip shown for cross-references to this function
+          parameter param.
+      :param arr: Tooltip shown for cross-references to this function
+          parameter arr.  To cross reference another parameter, use the
+          :rst:role:`cpp:expr` role, e.g.: :cpp:expr:`N`.  Parameters can
+          also be referenced via their fake qualified name,
+          e.g. :cpp:expr:`synopses_ex::Foo::N`.
+      :returns: Something or other.
+
+.. rst-example:: C++ function with parameter descriptions nested within class.
+
+   .. cpp:class:: synopses_ex::Class
+
+       .. cpp:function:: Class(uint16_t _cepin, uint16_t _cspin, uint32_t _spi_speed=RF24_SPI_SPEED)
+
+           :param _cepin: The pin attached to Chip Enable on the RF module
+           :param _cspin: The pin attached to Chip Select (often labeled CSN) on the radio module.
+           :param _spi_speed: The SPI speed in Hz ie: 1000000 == 1Mhz
 
 
 JavaScript API

--- a/docs/format_signatures.rst
+++ b/docs/format_signatures.rst
@@ -11,34 +11,37 @@ There is a CSS-based formatting rule that can be enabled for long function
 signatures that displays each function parameter on a separate line.  This is
 enabled by default, and works fairly well for Python signatures.
 
-.. confval:: html_wrap_signatures_with_css
+It is controlled by the following `object description
+options<object-description-options>`:
 
-   Specifies for which `Sphinx domains
-   <https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html>`__
-   this CSS-based formatting is enabled.
+.. objconf:: wrap_signatures_with_css
 
-   Supported types are:
+   Indicates whether CSS-based formatting is enabled.  Disabled automatically if
+   :objconf:`clang_format_style` is specified.
 
-   :py:obj:`bool`
-       If `True`, enable CSS-based formatting for all domains.  If `False`,
-       disable CSS-based formatting for all domains.
-
-   :py:obj:`list[str]`
-       List of domains for which to enable CSS-based formatting.
-
-   The default value is :python:`True`
-
-.. confval:: html_wrap_signatures_with_css_column_limit
+.. objconf:: wrap_signatures_column_limit
 
    Maximum signature length before function parameters are displayed on separate
    lines.
 
-   Only applies to domains for which :confval:`html_wrap_signatures_with_css` is
-   enabled.
+   Only applies if :objconf:`wrap_signatures_with_css` is set to :python:`True`,
+   or if :objconf:`clang_format_style` is enabled and does not specify a
+   ``ColumnLimit`` value.
 
-   The default value is :python:`68`.
+   The default value is :python:`68`.  This is the number of characters that fit
+   under typical display settings with both left and right side bars displayed.
 
-.. rst-example::
+For example, to disable this option for every domain except ``py``, add the
+following to :file:`conf.py`:
+
+.. code-block:: python
+
+   object_description_options = [
+       (".*": dict(wrap_signatures_with_css=False)),
+       ("py:.*": dict(wrap_signatures_with_css=True)),
+   ]
+
+.. rst-example:: CSS-based wrapping of Python signature
 
    .. py:function:: long_function_signature_example(\
                       name: int, \
@@ -55,8 +58,9 @@ There is a more powerful alternative formatting mechanism based on `clang-format
 JavaScript, Objective-C, and C#.
 
 This functionality is available as a separate extension included with this
-theme.  To use it, you must include it in your conf.py file and you must also
-set the :confval:`clang_format_signatures_domain_styles` configuration option.
+theme.  To use it, you must include it in your :file:`conf.py` file and you must
+also specify the :objconf:`clang_format_style` option for the object types for
+which the extension should be used.
 
 .. code-block:: python
 
@@ -65,35 +69,19 @@ set the :confval:`clang_format_signatures_domain_styles` configuration option.
         "sphinx_immaterial.format_signatures",
     ]
 
-    clang_format_signatures_domain_styles = {
-        "cpp": """{
-        BasedOnStyle: LLVM,
-        ColumnLimit: 68,
-        }""",
-    }
+    object_description_options = [
+        # ...
+        ("cpp:.*": dict(clang_format_style={"BasedOnStyle": "LLVM"})),
+    ]
 
-.. confval:: clang_format_signatures_domain_styles
+.. objconf:: clang_format_style
 
-   Dictionary that specifies the `clang-format style options
-   <https://clang.llvm.org/docs/ClangFormatStyleOptions.html>`__ for each
-   domain.  Formatting is enabled *only* for domains that are listed.
+   Specifies the `clang-format style options
+   <https://clang.llvm.org/docs/ClangFormatStyleOptions.html>`__ as a
+   :python:`dict` (JSON object), or :python:`None` to disable clang-format.
 
-   .. literalinclude:: conf.py
-      :language: python
-      :start-after: # BEGIN: sphinx_immaterial.format_signatures extension options
-      :end-before: # END: sphinx_immaterial.format_signatures extension options
-
-   When specifying an inline style (as opposed to a predefined style), it is
-   necessary to enclose the style in curly braces, as in the example above.
-   Since the predefined styles (such as ``Google``, ``LLVM``, etc.) do not use a
-   column limit of 68, it is not recommended to use a predefined style.
-
-   .. tip::
-
-      It is recommended to include ``ColumnLimit: 68`` as a style option.  This
-      is the default for the CSS-based wrapping, and is the number of characters
-      that fit under typical display settings with both left and right side bars
-      displayed.
+   If the style does not explicitly specify a ``ColumnLimit``, the value of
+   :objconf:`wrap_signatures_column_limit` is used.
 
    .. warning::
 
@@ -107,6 +95,7 @@ set the :confval:`clang_format_signatures_domain_styles` configuration option.
 
    Name of ``clang-format`` executable.  May either be a plain filename, in
    which case normal ``PATH`` resolution applies, or a path to the executable.
+   Defaults to :python:`"clang-format"`.
 
    To ensure that a consistent version of ``clang-format`` is available when
    building your documentation, add the `clang-format PyPI package

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sphinx>=4.0
 markupsafe
+pydantic

--- a/sphinx_immaterial/__init__.py
+++ b/sphinx_immaterial/__init__.py
@@ -18,6 +18,7 @@ from . import apidoc_formatting
 from . import autodoc_property_type
 from . import cpp_domain_fixes
 from . import inlinesyntaxhighlight
+from . import generic_synopses
 from . import nav_adapt
 from . import object_toc
 from . import postprocess_html
@@ -310,6 +311,7 @@ def setup(app):
     app.setup_extension(inlinesyntaxhighlight.__name__)
     app.setup_extension(object_toc.__name__)
     app.setup_extension(search_adapt.__name__)
+    app.setup_extension(generic_synopses.__name__)
     app.connect("html-page-context", html_page_context)
     app.connect("builder-inited", _builder_inited)
     app.add_config_value(

--- a/sphinx_immaterial/apidoc_formatting.py
+++ b/sphinx_immaterial/apidoc_formatting.py
@@ -1,14 +1,33 @@
 """Modifies the formatting of API documentation."""
 
-from typing import List, TYPE_CHECKING, cast
+import functools
+import re
+from typing import (
+    List,
+    TYPE_CHECKING,
+    cast,
+    Literal,
+    Optional,
+    Dict,
+    Tuple,
+    NamedTuple,
+    Any,
+    Pattern,
+)
 
 import docutils.nodes
+import pydantic
 import sphinx.addnodes
 import sphinx.application
 import sphinx.locale
+import sphinx.util.logging
 import sphinx.writers.html5
 
 _ = sphinx.locale._
+
+logger = sphinx.util.logging.getLogger(__name__)
+
+ObjectDescriptionOptions = Dict[str, Any]
 
 
 if TYPE_CHECKING:
@@ -141,18 +160,15 @@ def _wrap_signatures(
     objtype: str,
     content: docutils.nodes.Element,
 ) -> None:
-    enabled = app.config.html_wrap_signatures_with_css
-    if enabled is True or enabled is None:
-        pass
-    elif enabled is False:
-        return
-    elif domain not in enabled:
+    options = get_object_description_options(app.env, domain, objtype)
+    if (
+        not options["wrap_signatures_with_css"]
+        or options.get("clang_format_style") is not None
+    ):
         return
     signatures = content.parent[:-1]
     for signature in signatures:
-        _wrap_signature(
-            signature, app.config.html_wrap_signatures_with_css_column_limit
-        )
+        _wrap_signature(signature, options["wrap_signatures_column_limit"])
 
 
 def _monkey_patch_object_description_to_include_fields_in_toc():
@@ -161,7 +177,8 @@ def _monkey_patch_object_description_to_include_fields_in_toc():
     def run(self: sphinx.directives.ObjectDescription) -> List[docutils.nodes.Node]:
         nodes = orig_run(self)
 
-        if not self.env.config.include_object_description_fields_in_toc:
+        options = get_object_description_options(self.env, self.domain, self.objtype)
+        if not options["include_fields_in_toc"]:
             return nodes
 
         obj_desc = nodes[-1]
@@ -191,6 +208,212 @@ def _monkey_patch_object_description_to_include_fields_in_toc():
     sphinx.directives.ObjectDescription.run = run
 
 
+def format_object_description_tooltip(
+    env: sphinx.environment.BuildEnvironment,
+    options: ObjectDescriptionOptions,
+    base_title: str,
+    synopsis: Optional[str],
+) -> str:
+    title = base_title
+
+    domain = env.get_domain(options["domain"])
+
+    if options["include_object_type_in_xref_tooltip"]:
+        object_type = options["object_type"]
+        title += f" ({domain.get_type_name(domain.object_types[object_type])})"
+
+    if synopsis:
+        title += f" — {synopsis}"
+
+    return title
+
+
+DEFAULT_OBJECT_DESCRIPTION_OPTIONS: List[Tuple[str, dict]] = [
+    ("std:envvar", {"toc_icon_class": "alias", "toc_icon_text": "$"}),
+    ("js:module", {"toc_icon_class": "data", "toc_icon_text": "r"}),
+    ("js:function", {"toc_icon_class": "procedure", "toc_icon_text": "M"}),
+    ("js:method", {"toc_icon_class": "procedure", "toc_icon_text": "M"}),
+    ("js:class", {"toc_icon_class": "data", "toc_icon_text": "C"}),
+    ("js:data", {"toc_icon_class": "alias", "toc_icon_text": "V"}),
+    ("js:attribute", {"toc_icon_class": "alias", "toc_icon_text": "V"}),
+    ("json:schema", {"toc_icon_class": "data", "toc_icon_text": "J"}),
+    ("json:subschema", {"toc_icon_class": "sub-data", "toc_icon_text": "j"}),
+    ("py:class", {"toc_icon_class": "data", "toc_icon_text": "C"}),
+    ("py:function", {"toc_icon_class": "procedure", "toc_icon_text": "F"}),
+    ("py:method", {"toc_icon_class": "procedure", "toc_icon_text": "M"}),
+    ("py:classmethod", {"toc_icon_class": "procedure", "toc_icon_text": "M"}),
+    ("py:staticmethod", {"toc_icon_class": "procedure", "toc_icon_text": "M"}),
+    ("py:property", {"toc_icon_class": "alias", "toc_icon_text": "P"}),
+    ("py:attribute", {"toc_icon_class": "alias", "toc_icon_text": "A"}),
+    ("py:data", {"toc_icon_class": "alias", "toc_icon_text": "V"}),
+    ("py:parameter", {"toc_icon_class": "sub-data", "toc_icon_text": "p"}),
+    ("c:member", {"toc_icon_class": "alias", "toc_icon_text": "V"}),
+    ("c:var", {"toc_icon_class": "alias", "toc_icon_text": "V"}),
+    ("c:function", {"toc_icon_class": "procedure", "toc_icon_text": "F"}),
+    ("c:macro", {"toc_icon_class": "alias", "toc_icon_text": "D"}),
+    ("c:union", {"toc_icon_class": "data", "toc_icon_text": "U"}),
+    ("c:struct", {"toc_icon_class": "data", "toc_icon_text": "S"}),
+    ("c:enum", {"toc_icon_class": "data", "toc_icon_text": "E"}),
+    ("c:enumerator", {"toc_icon_class": "data", "toc_icon_text": "e"}),
+    ("c:type", {"toc_icon_class": "alias", "toc_icon_text": "T"}),
+    (
+        "c:macroParam",
+        {
+            "toc_icon_class": "sub-data",
+            "toc_icon_text": "p",
+            "generate_synopses": "first_sentence",
+        },
+    ),
+    ("cpp:class", {"toc_icon_class": "data", "toc_icon_text": "C"}),
+    ("cpp:struct", {"toc_icon_class": "data", "toc_icon_text": "S"}),
+    ("cpp:enum", {"toc_icon_class": "data", "toc_icon_text": "E"}),
+    ("cpp:enum-class", {"toc_icon_class": "data", "toc_icon_text": "E"}),
+    ("cpp:enum-struct", {"toc_icon_class": "data", "toc_icon_text": "E"}),
+    ("cpp:enumerator", {"toc_icon_class": "data", "toc_icon_text": "e"}),
+    ("cpp:union", {"toc_icon_class": "data", "toc_icon_text": "U"}),
+    ("cpp:concept", {"toc_icon_class": "data", "toc_icon_text": "t"}),
+    ("cpp:function", {"toc_icon_class": "procedure", "toc_icon_text": "F"}),
+    ("cpp:alias", {"toc_icon_class": "procedure", "toc_icon_text": "F"}),
+    ("cpp:member", {"toc_icon_class": "alias", "toc_icon_text": "V"}),
+    ("cpp:var", {"toc_icon_class": "alias", "toc_icon_text": "V"}),
+    ("cpp:type", {"toc_icon_class": "alias", "toc_icon_text": "T"}),
+    ("cpp:namespace", {"toc_icon_class": "alias", "toc_icon_text": "N"}),
+    (
+        "cpp:functionParam",
+        {
+            "toc_icon_class": "sub-data",
+            "toc_icon_text": "p",
+            "generate_synopses": "first_sentence",
+        },
+    ),
+    (
+        "cpp:templateTypeParam",
+        {
+            "toc_icon_class": "alias",
+            "toc_icon_text": "T",
+            "generate_synopses": "first_sentence",
+        },
+    ),
+    (
+        "cpp:templateNonTypeParam",
+        {
+            "toc_icon_class": "data",
+            "toc_icon_text": "N",
+            "generate_synopses": "first_sentence",
+        },
+    ),
+    (
+        "cpp:templateTemplateParam",
+        {
+            "toc_icon_class": "alias",
+            "toc_icon_text": "T",
+            "generate_synopses": "first_sentence",
+        },
+    ),
+]
+
+
+def get_object_description_option_registry(app: sphinx.application.Sphinx):
+    key = "sphinx_immaterial_object_description_option_registry"
+    registry = getattr(app, key, None)
+    if registry is None:
+        registry = {}
+        setattr(app, key, registry)
+    return registry
+
+
+class RegisteredObjectDescriptionOption(NamedTuple):
+    type_constraint: Any
+    default: Any
+
+
+def add_object_description_option(
+    app: sphinx.application.Sphinx, name: str, default: Any, type_constraint: type = Any
+) -> None:
+    registry = get_object_description_option_registry(app)
+    if name in registry:
+        logger.error(f"Object description option {name!r} already registered")
+    default = pydantic.parse_obj_as(type_constraint, default)
+    registry[name] = RegisteredObjectDescriptionOption(
+        default=default, type_constraint=type_constraint
+    )
+
+
+def get_object_description_options(
+    env: sphinx.environment.BuildEnvironment, domain: str, object_type: str
+) -> ObjectDescriptionOptions:
+
+    return env.app._sphinx_immaterial_get_object_description_options(
+        domain, object_type
+    )
+
+
+def _builder_inited(app: sphinx.application.Sphinx) -> None:
+
+    registry = get_object_description_option_registry(app)
+    options_map: Dict[str, List[Tuple[int, Dict[str, Any]]]] = {}
+    options_patterns: List[Tuple[Pattern, int, Dict[str, Any]]] = []
+
+    default_options = {}
+    for name, registered_option in registry.items():
+        default_options[name] = registered_option.default
+
+    # Validate options
+    for i, (pattern, options) in enumerate(
+        pydantic.parse_obj_as(
+            List[Tuple[Pattern, Dict[str, Any]]],
+            DEFAULT_OBJECT_DESCRIPTION_OPTIONS + app.config.object_description_options,
+        )
+    ):
+        for name, value in options.items():
+            registered_option = registry.get(name)
+            if registered_option is None:
+                logger.error(
+                    "Undefined object description option %r specified for pattern %r",
+                    name,
+                    pattern.pattern,
+                )
+                continue
+            try:
+                options[name] = pydantic.parse_obj_as(
+                    registered_option.type_constraint, value
+                )
+            except Exception as e:  # pylint: disable=broad-except
+                logger.error(
+                    "Invalid value %r for object description option"
+                    " %r specified for pattern %r: %s",
+                    value,
+                    name,
+                    pattern.pattern,
+                    e,
+                )
+        if pattern.pattern == re.escape(pattern.pattern):
+            # Pattern just matches a single string.
+            options_map.setdefault(pattern.pattern, []).append((i, options))
+        else:
+            options_patterns.append((pattern, i, options))
+
+    @functools.lru_cache(maxsize=None)
+    def get_options(domain: str, object_type: str) -> Dict[str, Any]:
+        key = f"{domain}:{object_type}"
+        matches = options_map.get(key)
+        if matches is None:
+            matches = []
+        else:
+            matches = list(matches)
+        for pattern, i, options in options_patterns:
+            if pattern.fullmatch(key):
+                matches.append((i, options))
+        matches.sort(key=lambda x: x[0])
+        full_options = default_options.copy()
+        for _, m in matches:
+            full_options.update(m)
+        full_options.update(domain=domain, object_type=object_type)
+        return full_options
+
+    app._sphinx_immaterial_get_object_description_options = get_options
+
+
 def setup(app: sphinx.application.Sphinx):
     """Registers the monkey patches.
 
@@ -200,17 +423,41 @@ def setup(app: sphinx.application.Sphinx):
     # to apply.
     sphinx.addnodes.desc_signature.classes.append("highlight")
 
-    app.add_config_value("html_wrap_signatures_with_css", default=None, rebuild="env")
-    app.add_config_value(
-        "html_wrap_signatures_with_css_column_limit", default=68, rebuild="env"
-    )
-
-    app.add_config_value(
-        "include_object_description_fields_in_toc", default=True, rebuild="env"
-    )
-
     app.connect("object-description-transform", _wrap_signatures)
     _monkey_patch_object_description_to_include_fields_in_toc()
+
+    add_object_description_option(
+        app, "wrap_signatures_with_css", type_constraint=bool, default=True
+    )
+    add_object_description_option(
+        app, "wrap_signatures_column_limit", type_constraint=int, default=68
+    )
+    add_object_description_option(
+        app, "include_in_toc", type_constraint=bool, default=True
+    )
+    add_object_description_option(
+        app, "include_fields_in_toc", type_constraint=bool, default=True
+    )
+    add_object_description_option(
+        app,
+        "generate_synopses",
+        type_constraint=Optional[Literal["first_paragraph", "first_sentence"]],
+        default="first_paragraph",
+    )
+    add_object_description_option(
+        app, "include_object_type_in_xref_tooltip", type_constraint=bool, default=True
+    )
+    add_object_description_option(
+        app, "toc_icon_text", type_constraint=Optional[str], default=None
+    )
+    add_object_description_option(
+        app, "toc_icon_class", type_constraint=Optional[str], default=None
+    )
+
+    app.add_config_value(
+        "object_description_options", default=[], rebuild="env", types=(list,)
+    )
+    app.connect("builder-inited", _builder_inited)
 
     return {
         "parallel_read_safe": True,

--- a/sphinx_immaterial/generic_synopses.py
+++ b/sphinx_immaterial/generic_synopses.py
@@ -1,0 +1,185 @@
+"""Adds synopsis support to the std domain."""
+
+from typing import cast, Optional, List, Iterator, Tuple
+
+import docutils.nodes
+import sphinx.application
+
+from . import apidoc_formatting
+from . import sphinx_utils
+
+
+def _monkey_patch_generic_object_to_support_synopses():
+
+    StandardDomain = sphinx.domains.std.StandardDomain
+
+    object_class = sphinx.domains.std.GenericObject
+
+    orig_after_content = object_class.after_content
+
+    orig_transform_content = object_class.transform_content
+
+    def transform_content(self: object_class, contentnode) -> None:
+        self.contentnode = contentnode
+        orig_transform_content(self, contentnode)
+
+    orig_add_target_and_index = object_class.add_target_and_index
+
+    def add_target_and_index(
+        self: object_class, name: str, sig: str, signode: sphinx.addnodes.desc_signature
+    ) -> None:
+        self._saved_object_name = name
+        orig_add_target_and_index(self, name, sig, signode)
+
+    object_class.add_target_and_index = add_target_and_index
+
+    object_class.transform_content = transform_content
+
+    def after_content(self: object_class) -> None:
+        orig_after_content(self)
+        options = apidoc_formatting.get_object_description_options(
+            self.env, self.domain, self.objtype
+        )
+        generate_synopses = options["generate_synopses"]
+        if generate_synopses is None:
+            return
+        synopsis = sphinx_utils.summarize_element_text(
+            self.contentnode, generate_synopses
+        )
+        std = cast(StandardDomain, self.env.get_domain("std"))
+        std.data["synopses"][self.objtype, self._saved_object_name] = synopsis
+
+    object_class.after_content = after_content
+
+    orig_merge_domaindata = StandardDomain.merge_domaindata
+
+    def merge_domaindata(self, docnames: List[str], otherdata: dict) -> None:
+        orig_merge_domaindata(self, docnames, otherdata)
+        self.data["synopses"].update(otherdata["synopses"])
+
+    StandardDomain.merge_domaindata = merge_domaindata
+
+    def make_refnode(
+        std: StandardDomain,
+        builder: sphinx.builders.Builder,
+        fromdocname: str,
+        docname: str,
+        labelid: str,
+        contnode: docutils.nodes.Element,
+        objtype: str,
+        target: str,
+    ):
+        return sphinx.util.nodes.make_refnode(
+            builder,
+            fromdocname,
+            docname,
+            labelid,
+            contnode,
+            title=apidoc_formatting.format_object_description_tooltip(
+                env=builder.env,
+                options=apidoc_formatting.get_object_description_options(
+                    std.env, "std", objtype
+                ),
+                base_title=target,
+                synopsis=std.data["synopses"].get((objtype, target)),
+            ),
+        )
+
+    def _resolve_obj_xref(
+        self: StandardDomain,
+        env: sphinx.environment.BuildEnvironment,
+        fromdocname: str,
+        builder: sphinx.builders.Builder,
+        typ: str,
+        target: str,
+        node: sphinx.addnodes.pending_xref,
+        contnode: docutils.nodes.Element,
+    ) -> Optional[docutils.nodes.Element]:
+        objtypes = self.objtypes_for_role(typ) or []
+        objtype = None
+        for objtype in objtypes:
+            result = self.objects.get((objtype, target))
+            if result is not None:
+                docname, labelid = result
+                break
+        else:
+            return None
+
+        return make_refnode(
+            self, builder, fromdocname, docname, labelid, contnode, objtype, target
+        )
+
+    StandardDomain._resolve_obj_xref = _resolve_obj_xref
+
+    def resolve_any_xref(
+        self: StandardDomain,
+        env: sphinx.environment.BuildEnvironment,
+        fromdocname: str,
+        builder: sphinx.builders.Builder,
+        target: str,
+        node: sphinx.addnodes.pending_xref,
+        contnode: docutils.nodes.Element,
+    ) -> List[Tuple[str, docutils.nodes.Element]]:
+        results: List[Tuple[str, docutils.nodes.Element]] = []
+        ltarget = target.lower()  # :ref: lowercases its target automatically
+        for role in ("ref", "option"):  # do not try "keyword"
+            res = self.resolve_xref(
+                env,
+                fromdocname,
+                builder,
+                role,
+                ltarget if role == "ref" else target,
+                node,
+                contnode,
+            )
+            if res:
+                results.append(("std:" + role, res))
+        # all others
+        for objtype in self.object_types:
+            key = (objtype, target)
+            if objtype == "term":
+                key = (objtype, ltarget)
+            if key in self.objects:
+                docname, labelid = self.objects[key]
+                results.append(
+                    (
+                        "std:" + self.role_for_objtype(objtype),
+                        make_refnode(
+                            self,
+                            builder,
+                            fromdocname,
+                            docname,
+                            labelid,
+                            contnode,
+                            objtype,
+                            target,
+                        ),
+                    )
+                )
+        return results
+
+    StandardDomain.resolve_any_xref = resolve_any_xref
+
+    def get_object_synopses(
+        self: StandardDomain,
+    ) -> Iterator[Tuple[Tuple[str, str], str]]:
+        synopses = self.data["synopses"]
+        for (objtype, name), (docname, labelid) in self.objects.items():
+            synopsis = synopses.get((objtype, name))
+            if not synopsis:
+                continue
+            yield ((docname, labelid), synopsis)
+
+    StandardDomain.get_object_synopses = get_object_synopses
+
+
+def setup(app: sphinx.application.Sphinx):
+    sphinx.domains.std.StandardDomain.initial_data[
+        "synopses"
+    ] = {}  # (type, name) -> synopsis
+    _monkey_patch_generic_object_to_support_synopses()
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/sphinx_immaterial/sphinx_utils.py
+++ b/sphinx_immaterial/sphinx_utils.py
@@ -1,10 +1,13 @@
 """Utilities for use with Sphinx."""
 
+from typing import Literal
+
 import docutils.nodes
 
 
 def summarize_element_text(
-    node: docutils.nodes.Element, first_sentence_only=True
+    node: docutils.nodes.Element,
+    mode: Literal["first_paragraph", "first_sentence"] = "first_paragraph",
 ) -> str:
     """Extracts a short text synopsis, e.g. for use as a tooltip."""
 
@@ -19,7 +22,7 @@ def summarize_element_text(
             break
 
     text = node.astext()
-    if first_sentence_only:
+    if mode == "first_sentence":
         sentence_end = text.find(". ")
         if sentence_end != -1:
             text = text[: sentence_end + 1]

--- a/src/assets/stylesheets/main/_api.scss
+++ b/src/assets/stylesheets/main/_api.scss
@@ -244,7 +244,7 @@ $objinfo-icon-size: 16px;
   border: 1px solid var(--objinfo-icon-fg-default);
   border-radius: 2px;
 
-  @each $objclass in (data, alias, procedure, data, sub-data) {
+  @each $objclass in (alias, procedure, data, sub-data) {
     &__#{$objclass} {
       color: var(--objinfo-icon-bg-default);
       background-color: var(--objinfo-icon-fg-#{$objclass});


### PR DESCRIPTION
This replaces manny config options with a more general "object
description options" mechanism that allows various options to be
configured on a per domain/object type basis.

This commit also adds a number of features built on top of that mechanism:

- Generating object description synopses for the std domain, including
  custom object types added using `app.add_object_type`.

- Excluding certain object types from the TOC

- Excluding the object type from the cross-reference tooltip.

Fixes #70.