### PR TITLE
Use typing_extensions to support Python 3.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,10 @@ jobs:
         os:
           - 'ubuntu-latest'
         python-version:
+          - '3.7'
+          - '3.8'
           - '3.9'
+          - '3.10'
         node-version:
           - '16.x'
     runs-on: ${{ matrix.os }}
@@ -56,13 +59,14 @@ jobs:
       working-directory: docs
       run: sphinx-build -b latex . _build/latex
     - name: Upload doc builds as artifacts
+      if: ${{ matrix.python-version == '3.10' }}
       uses: actions/upload-artifact@v2
       with:
         name: doc-builds
         path: docs/_build/
     - name: upload docs to github pages
       # if: ${{ github.event_name == 'release'}}
-      if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+      if: ${{ matrix.python-version == '3.10' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
       uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305 # pinned to v3.8.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx>=4.0
 markupsafe
 pydantic
+typing-extensions

--- a/sphinx_immaterial/apidoc_formatting.py
+++ b/sphinx_immaterial/apidoc_formatting.py
@@ -6,7 +6,6 @@ from typing import (
     List,
     TYPE_CHECKING,
     cast,
-    Literal,
     Optional,
     Dict,
     Tuple,
@@ -22,6 +21,7 @@ import sphinx.application
 import sphinx.locale
 import sphinx.util.logging
 import sphinx.writers.html5
+from typing_extensions import Literal
 
 _ = sphinx.locale._
 

--- a/sphinx_immaterial/sphinx_utils.py
+++ b/sphinx_immaterial/sphinx_utils.py
@@ -1,6 +1,6 @@
 """Utilities for use with Sphinx."""
 
-from typing import Literal
+from typing_extensions import Literal
 
 import docutils.nodes
 


### PR DESCRIPTION
This also adds a github actions build for Python 3.7, 3.8, and 3.10.

Fixes #84.