### PR TITLE
Remove redundant "/" when loading search js

### DIFF
--- a/src/assets/javascripts/sphinx_search.ts
+++ b/src/assets/javascripts/sphinx_search.ts
@@ -27,7 +27,7 @@ const config = configuration()
  * @returns The full URL.
  */
 function getAbsoluteUrl(path: string): string {
-  return `${config.base}/${path}`
+  return `${config.base}${path}`
 }
 
 let searchIndexLoaded: Promise<void> | undefined


### PR DESCRIPTION
Fixes #94

Removes redundant `/` when loading search-related resources.