### PR TITLE
Build and upload tarballs with sdist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,14 @@ jobs:
     - name: Show package version
       run: python setup.py --version
     - name: Build wheel
-      run: python setup.py bdist_wheel
+      run: python setup.py sdist bdist_wheel
     - name: Upload wheels as artifacts
       uses: actions/upload-artifact@v2
       with:
         name: python-packages
-        path: dist/*.whl
+        path: |
+          dist/*.whl
+          dist/*.tar.*
     - name: Install wheel and docs' dependencies
       run: pip install dist/*.whl -r docs/requirements.txt
     - name: Build html docs


### PR DESCRIPTION
This PR modifies the GA workflow to build and upload `sdist` source distributions.

Closes #96.