### PR TITLE
Tweaking patched PropertyDocumenter to support cached_property, fixes #104

### DIFF
--- a/docs/test_py_module/test.py
+++ b/docs/test_py_module/test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Test Module for sphinx_rtd_theme."""
+import functools
 from typing import Union
 
 
@@ -112,6 +113,17 @@ class Foo:
             This is deprecated since 3.0
         """
         return sum(kwargs.values()) / len(kwargs), a + b
+
+    @property
+    def qux_caps(self) -> str:
+        """Return the instance qux as uppercase."""
+        return self.capitalize(self.qux)
+
+    @functools.cached_property
+    def qux_caps_cached(self) -> str:
+        """Return the cached value of instance qux as uppercase."""
+        return self.qux_caps
+
 
 def func(long: int, param: str, args: None, flags: bool, lists: Union[list, tuple]):
     """A function with many parameters."""

--- a/sphinx_immaterial/autodoc_property_type.py
+++ b/sphinx_immaterial/autodoc_property_type.py
@@ -15,9 +15,10 @@ property_sig_re = re.compile("^(\\(.*)\\)\\s*->\\s*(.*)$")
 
 
 def _get_property_return_type(obj: property) -> Optional[str]:
-    if obj.fget is None:
-        return None
-    doc = obj.fget.__doc__
+    fget = getattr(obj, "fget", None)
+    if fget is not None:
+        obj = fget
+    doc = obj.__doc__
     if doc is None:
         return None
     line = doc.splitlines()[0]


### PR DESCRIPTION
This is a simple fix addressing the #104 by falling back to retrieving the `__doc__` directly from the `obj` if there is no `.fget` attribute available.