### PR TITLE
add cross_link_parameter_description option

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -135,6 +135,26 @@ The following options can be customized for each object type using
              ("py:.*", dict(include_fields_in_toc=False)),
          ]
 
+.. objconf:: cross_link_parameter_descriptions
+
+   This option can be used to prevent the cross linking of parameter descriptions to their
+   declarations in the a function signature. This was specifically provided for the C/C++
+   domains because omitting parameter names in C/C++ prototypes is conventionally allowed.
+   However, it can also be disabled in the python domain when using non-pythonic optional
+   syntax as seen in our `format_exception()` example.
+
+   .. admonition:: Example
+      :class: example
+
+      By default, this option is enabled (`True`), but it can be disabled by setting this
+      option to `False`.
+
+      .. code-block:: python
+
+         object_description_options = [
+            ("cpp:function", dict(cross_link_parameter_descriptions=False)),
+         ]
+
 Other options described elsewhere include:
 
 - :objconf:`wrap_signatures_with_css`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -146,7 +146,7 @@ The following options can be customized for each object type using
 .. objconf:: cross_link_parameter_descriptions
 
    This option can be used to prevent the cross linking of parameter descriptions to their
-   declarations in the a function signature. This was specifically provided for the C/C++
+   declarations in the a signature. This was specifically provided for the C/C++
    domains because omitting parameter names in C/C++ prototypes is conventionally allowed.
    However, it can also be disabled in the python domain when using non-pythonic optional
    syntax as seen in our `format_exception()` example.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,14 @@ domain/object type pair.
    initializing each option to its default value, and then applying as overrides
    the options associated with each matching pattern in order.
 
+   .. details:: Here's the list of supported patterns (and their default configuration)
+      :class: faq
+
+      .. literalinclude:: ../sphinx_immaterial/apidoc_formatting.py
+         :language: python
+         :start-at: DEFAULT_OBJECT_DESCRIPTION_OPTIONS
+         :end-before: # end DEFAULT_OBJECT_DESCRIPTION_OPTIONS
+
 .. _object-description-options:
 
 Object description options

--- a/sphinx_immaterial/apidoc_formatting.py
+++ b/sphinx_immaterial/apidoc_formatting.py
@@ -477,6 +477,9 @@ def setup(app: sphinx.application.Sphinx):
     add_object_description_option(
         app, "toc_icon_class", type_constraint=Optional[str], default=None
     )
+    add_object_description_option(
+        app, "cross_link_parameter_descriptions", type_constraint=bool, default=True
+    )
 
     app.add_config_value(
         "object_description_options",

--- a/sphinx_immaterial/apidoc_formatting.py
+++ b/sphinx_immaterial/apidoc_formatting.py
@@ -335,6 +335,7 @@ DEFAULT_OBJECT_DESCRIPTION_OPTIONS: List[Tuple[str, dict]] = [
     ("rst:directive:option", {"toc_icon_class": "sub-data", "toc_icon_text": "o"}),
     ("rst:role", {"toc_icon_class": "procedure", "toc_icon_text": "R"}),
 ]
+# end DEFAULT_OBJECT_DESCRIPTION_OPTIONS
 
 
 def get_object_description_option_registry(app: sphinx.application.Sphinx):

--- a/sphinx_immaterial/cpp_domain_fixes.py
+++ b/sphinx_immaterial/cpp_domain_fixes.py
@@ -749,9 +749,9 @@ def _add_parameter_documentation_ids(
                 all_params.update(sig_param_nodes)
             logger.warning(
                 "Parameter name %r does not match any of the parameters "
-                "defined in the signature: %r",
+                "defined in the signature(s): %r",
                 param_name,
-                obj_content.parent.children[0].astext(),
+                [n.astext() for n in obj_content.parent.children[:-1]],
                 location=param_node,
             )
             return

--- a/sphinx_immaterial/cpp_domain_fixes.py
+++ b/sphinx_immaterial/cpp_domain_fixes.py
@@ -751,7 +751,7 @@ def _add_parameter_documentation_ids(
                 "Parameter name %r does not match any of the parameters "
                 "defined in the signature: %r",
                 param_name,
-                list(all_params.keys()),
+                obj_content.parent.children[0].astext(),
                 location=param_node,
             )
             return
@@ -975,16 +975,19 @@ def _monkey_patch_domain_to_cross_link_parameters_and_add_synopses(
         while symbols[-1].siblingAbove:
             symbols.append(symbols[-1].siblingAbove)
         symbols.reverse()
-        _cross_link_parameters(
-            app=self.env.app,
-            domain=domain,
-            content=getattr(self, "contentnode"),
-            symbols=symbols,
-        )
 
         options = apidoc_formatting.get_object_description_options(
             self.env, self.domain, self.objtype
         )
+
+        if options["cross_link_parameter_descriptions"]:
+            _cross_link_parameters(
+                app=self.env.app,
+                domain=domain,
+                content=getattr(self, "contentnode"),
+                symbols=symbols,
+            )
+
         generate_synopses = options["generate_synopses"]
 
         if generate_synopses is not None:

--- a/sphinx_immaterial/cpp_domain_fixes.py
+++ b/sphinx_immaterial/cpp_domain_fixes.py
@@ -749,9 +749,10 @@ def _add_parameter_documentation_ids(
                 all_params.update(sig_param_nodes)
             logger.warning(
                 "Parameter name %r does not match any of the parameters "
-                "defined in the signature(s): %r",
+                "defined in the signature(s): %r\n\tList of known parameters %r",
                 param_name,
                 [n.astext() for n in obj_content.parent.children[:-1]],
+                list(all_params.keys()),
                 location=param_node,
             )
             return

--- a/sphinx_immaterial/cpp_domain_fixes.py
+++ b/sphinx_immaterial/cpp_domain_fixes.py
@@ -798,7 +798,7 @@ def _add_parameter_documentation_ids(
 
             # Set symbol id, since by default parameters don't have unique ids,
             # they just use the same id as the parent symbol.  This is
-            # neccessary in order for cross links to correctly refer to the
+            # necessary in order for cross links to correctly refer to the
             # parameter description.
             setattr(
                 param_symbol.declaration,
@@ -866,7 +866,7 @@ def _add_parameter_documentation_ids(
         param_node.parent[:1] = new_param_nodes
 
     # Find all parameter descriptions within the object description body.  Make
-    # sure not to find parameter descriptions within neted object descriptions.
+    # sure not to find parameter descriptions within nested object descriptions.
     # For example, if this is a class object description, we don't want to find
     # parameter descriptions within a nested function object description.
     for child in obj_content:

--- a/sphinx_immaterial/python_domain_fixes.py
+++ b/sphinx_immaterial/python_domain_fixes.py
@@ -474,9 +474,10 @@ def _add_parameter_documentation_ids(
                 all_params.update(sig_param_nodes)
             logger.warning(
                 "Parameter name %r does not match any of the parameters "
-                "defined in the signature(s): %r",
+                "defined in the signature(s): %r\n\tList of known parameters: %r",
                 param_name,
                 [n.astext() for n in obj_content.parent.children[:-1]],
+                list(all_params.keys()),
                 location=param_node,
             )
             return
@@ -555,7 +556,7 @@ def _add_parameter_documentation_ids(
         return
 
     # Find all parameter descriptions within the object description body.  Make
-    # sure not to find parameter descriptions within neted object descriptions.
+    # sure not to find parameter descriptions within nested object descriptions.
     # For example, if this is a class object description, we don't want to find
     # parameter descriptions within a nested function object description.
     for child in obj_content:

--- a/sphinx_immaterial/python_domain_fixes.py
+++ b/sphinx_immaterial/python_domain_fixes.py
@@ -476,7 +476,7 @@ def _add_parameter_documentation_ids(
                 "Parameter name %r does not match any of the parameters "
                 "defined in the signature: %r",
                 param_name,
-                list(all_params.keys()),
+                obj_content.parent.children[0].astext(),
                 location=param_node,
             )
             return
@@ -544,6 +544,15 @@ def _add_parameter_documentation_ids(
                     child.line = line
                 new_param_nodes.append(new_param_node)
             param_node.parent[:1] = new_param_nodes
+
+    func_options = apidoc_formatting.get_object_description_options(
+        env, "py", "function"
+    )
+    if (
+        not func_options["cross_link_parameter_descriptions"]
+        or not param_options["cross_link_parameter_descriptions"]
+    ):
+        return
 
     # Find all parameter descriptions within the object description body.  Make
     # sure not to find parameter descriptions within neted object descriptions.

--- a/sphinx_immaterial/python_domain_fixes.py
+++ b/sphinx_immaterial/python_domain_fixes.py
@@ -474,9 +474,9 @@ def _add_parameter_documentation_ids(
                 all_params.update(sig_param_nodes)
             logger.warning(
                 "Parameter name %r does not match any of the parameters "
-                "defined in the signature: %r",
+                "defined in the signature(s): %r",
                 param_name,
-                obj_content.parent.children[0].astext(),
+                [n.astext() for n in obj_content.parent.children[:-1]],
                 location=param_node,
             )
             return


### PR DESCRIPTION
solves #112 

I also added a collapsed list of the supported `object_description_options` patterns in the _api.rst_ for completeness (helpful for undocumented object types).