### PR TITLE
Some cpp comment stripping parsing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -331,6 +331,7 @@ cpp_apigen_configs = [
             },
             allow_paths=["^cpp_apigen_demo/"],
             disallow_namespaces=["^std$"],
+            verbose=True,
         ),
     ),
 ]

--- a/docs/cpp_apigen_demo/array.h
+++ b/docs/cpp_apigen_demo/array.h
@@ -56,6 +56,7 @@ class Array {
   ///
   /// \param index The index vector, or an integer index in the case that
   ///     `Rank == 1`.
+  ///
   template <int SfinaeRank = Rank, typename = std::enable_if_t<SfinaeRank == 1>>
   T operator[](int index);
   T operator[](std::array<int, Rank> index);

--- a/docs/cpp_apigen_demo/array.h
+++ b/docs/cpp_apigen_demo/array.h
@@ -54,9 +54,7 @@ class Array {
 
   /// Returns the element at the specified index or index vector.
   ///
-  /// \param index The index vector, or an integer index in the case that
-  ///     `Rank == 1`.
-  ///
+  /// \param index The index vector, or an integer index in the case that `Rank == 1`.
   template <int SfinaeRank = Rank, typename = std::enable_if_t<SfinaeRank == 1>>
   T operator[](int index);
   T operator[](std::array<int, Rank> index);

--- a/docs/cpp_apigen_demo/index_interval.h
+++ b/docs/cpp_apigen_demo/index_interval.h
@@ -21,7 +21,7 @@ class IndexInterval {
 
   /// Returns the lower bound.
   ///
-  //! @retval int The lower bound.
+  //! @returns The lower bound.
   int lower() const;
 
   /// Returns the upper bound.

--- a/docs/cpp_apigen_demo/index_interval.h
+++ b/docs/cpp_apigen_demo/index_interval.h
@@ -20,6 +20,8 @@ class IndexInterval {
   friend std::ostream& operator<<(std::ostream& os, IndexInterval x);
 
   /// Returns the lower bound.
+  ///
+  //! @retval int The lower bound.
   int lower() const;
 
   /// Returns the upper bound.

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -165,9 +165,9 @@ class Config:
     defined in the standard library and third-party libraries.
 
     .. important::
-        Because this is used as a Regular Expression patterns, this should end in
-        (and exclusively use) the Linux path separator :python:`"/"` (even if
-        building on Windows).
+        When building on Windows, all path separators are normalized to :python:`"/"`. 
+        Therefore, in the specified regular expressions, always use :python:`"/"` to
+        match a path separator.
     """
 
     disallow_paths: List[Pattern] = dataclasses.field(default_factory=list)
@@ -176,9 +176,9 @@ class Config:
     Entities defined in files matching any of these patterns are not documented.
 
     .. important::
-        Because this is used as a Regular Expression patterns, this should end in
-        (and exclusively use) the Linux path separator :python:`"/"` (even if
-        building on Windows).
+        When building on Windows, all path separators are normalized to :python:`"/"`. 
+        Therefore, in the specified regular expressions, always use :python:`"/"` to
+        match a path separator.
     """
 
     disallow_namespaces: List[Pattern] = dataclasses.field(default_factory=list)

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -164,12 +164,21 @@ class Config:
     but this default is not normally usable, because it will include entities
     defined in the standard library and third-party libraries.
 
+    .. important::
+        Because this is used as a Regular Expression patterns, this should end in
+        (and exclusively use) the Linux path separator :python:`"/"` (even if
+        building on Windows).
     """
 
     disallow_paths: List[Pattern] = dataclasses.field(default_factory=list)
     """List of regular expressions matching *disallowed* paths.
 
     Entities defined in files matching any of these patterns are not documented.
+
+    .. important::
+        Because this is used as a Regular Expression patterns, this should end in
+        (and exclusively use) the Linux path separator :python:`"/"` (even if
+        building on Windows).
     """
 
     disallow_namespaces: List[Pattern] = dataclasses.field(default_factory=list)

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -124,16 +124,16 @@ class Config:
     input_path: str = "__input.cpp"
     """Path to the input file to parse.
 
-    This may either be a path to an existing file, or `input_content` may
+    This may either be a path to an existing file, or :py:attr:`input_content` may
     specify its content, in which case the filesystem is not accessed.
 
-    If `input_content` is specified and merely contains :cpp:`#include`
+    If :py:attr:`input_content` is specified and merely contains :cpp:`#include`
     directives, then the actual path does not matter and may be left as the
     default value.
     """
 
     input_content: Optional[bytes] = None
-    """Specifies the content of `input_path`.
+    """Specifies the content of :py:attr:`input_path`.
 
     If unspecified, the content is read from filesystem.
     """
@@ -184,8 +184,8 @@ class Config:
     )
     """List of regular expressions matching *allowed* symbols.
 
-    Only symbols matching one of the `allow_symbols` patterns, and not matching
-    `disallow_symbols`, are documented.  By default, all symbols are allowed.
+    Only symbols matching one of the :py:attr:`allow_symbols` patterns, and not matching
+    :py:attr:`disallow_symbols`, are documented.  By default, all symbols are allowed.
     """
 
     disallow_symbols: List[Pattern] = dataclasses.field(default_factory=list)
@@ -199,8 +199,8 @@ class Config:
     )
     """List of regular expressions matching *allowed* macros.
 
-    Only macros names matching `allow_macros`, and not matching
-    `disallow_macros`, are documented.
+    Only macros names matching :py:attr:`allow_macros`, and not matching
+    :py:attr:`disallow_macros`, are documented.
     """
 
     disallow_macros: List[Pattern] = dataclasses.field(default_factory=list)

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -490,13 +490,12 @@ def get_doc_comment(config: Config, cursor: Cursor):
     f = location.file
     line = location.line
     end_location = SourceLocation.from_position(translation_unit, f, line, 1)
-    comment = ""
     if cursor.raw_comment:
-        comment = "\n".join(split_doc_comment_into_lines(cursor.raw_comment))
-    return {
-        "text": comment,
-        "location": _get_location_json(config, end_location),
-    }
+        return {
+            "text": "\n".join(split_doc_comment_into_lines(cursor.raw_comment)),
+            "location": _get_location_json(config, end_location),
+        }
+    return None
 
 
 class Extractor:

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -58,13 +58,15 @@ from typing import (
 import ctypes
 
 import clang.cindex
-from clang.cindex import Cursor
-from clang.cindex import CursorKind
-from clang.cindex import Token
-from clang.cindex import TokenKind
-from clang.cindex import TranslationUnit
-from clang.cindex import SourceLocation
-from clang.cindex import SourceRange
+from clang.cindex import (
+    Cursor,
+    CursorKind,
+    Token,
+    TokenKind,
+    TranslationUnit,
+    SourceLocation,
+    SourceRange,
+)
 import docutils.nodes
 import pydantic.dataclasses
 import sphinx.domains.cpp

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -446,9 +446,7 @@ def split_doc_comment_into_lines(cmt: str) -> List[str]:
     :param cmt: the comment to parse.
     :returns: A list of the lines without the surrounding C++ comment syntax.
     """
-    if cmt is None:
-        return [""]
-    # the first line is never indented (in clang-parsed form)
+    # the first line is never indented (in `raw_comment` form)
     # so dedent all subsequent lines only
     first_line_end = cmt.find("\n")
     cmt = cmt[:first_line_end] + dedent(cmt[first_line_end:])

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -318,7 +318,7 @@ class Config:
         if mapped is not None:
             return mapped
         if os.name == "nt":
-            path = path.replace("/", "\\")
+            path = path.replace("\\", "/")
         if path.startswith("./"):
             path = path[2:]
         new_mapped = self.include_directory_map_pattern.sub(

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -469,7 +469,8 @@ def split_doc_comment_into_lines(cmt: str) -> List[str]:
             for line in body
         ]
         body[-1] = body[-1].rstrip("*/").rstrip()
-    body = dedent("\n".join(body)).splitlines()
+    if len(body) > 1:
+        body = dedent("\n".join(body)).splitlines()
     return [""] if not body else body
 
 

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -2182,6 +2182,8 @@ def organize_entities(config: Config, entities: Dict[EntityId, CppApiEntity]):
 
 def _get_output_json(extractor: Extractor):
     generator = JsonApiGenerator(extractor)
+    if extractor.config.verbose:
+        logger.info("Found %d C++ declarations", len(extractor.decls))
     for decl in extractor.decls:
         generator.add(decl)
     return organize_entities(extractor.config, generator.seen_decls)

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -483,11 +483,16 @@ def get_doc_comment(config: Config, cursor: Cursor):
         break
     else:
         location = cursor.location
-    initial_location = location
     f = location.file
     line = location.line
-    presumed_file, presumed_line, presumed_column = get_presumed_location(location)
     end_location = SourceLocation.from_position(translation_unit, f, line, 1)
+    if cursor.raw_comment and DOC_COMMENT_PREFIX.match(cursor.raw_comment):
+        return {
+            "text": "\n".join(split_doc_comment_into_lines(cursor.raw_comment)),
+            "location": _get_location_json(config, end_location),
+        }
+    initial_location = location
+    presumed_file, presumed_line, presumed_column = get_presumed_location(location)
     comment_lines = []
     COMMENT = TokenKind.COMMENT
     while True:

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -130,7 +130,7 @@ class Config:
     """
 
     input_content: Optional[bytes] = None
-    """Specifies the content of `.input_path`.
+    """Specifies the content of `input_path`.
 
     If unspecified, the content is read from filesystem.
     """
@@ -181,7 +181,7 @@ class Config:
     )
     """List of regular expressions matching *allowed* symbols.
 
-    Only symbols matching one of the `.allow_symbols` patterns, and not matching
+    Only symbols matching one of the `allow_symbols` patterns, and not matching
     `disallow_symbols`, are documented.  By default, all symbols are allowed.
     """
 
@@ -196,8 +196,8 @@ class Config:
     )
     """List of regular expressions matching *allowed* macros.
 
-    Only macros names matching `.allow_macros`, and not matching
-    `.disallow_macros`, are documented.
+    Only macros names matching `allow_macros`, and not matching
+    `disallow_macros`, are documented.
     """
 
     disallow_macros: List[Pattern] = dataclasses.field(default_factory=list)

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -441,7 +441,7 @@ def _get_all_decls(config: Config, cursor: Cursor, allow_file):
             yield from _get_all_decls(config, child, None)
 
 
-def strip_comment(cmt: str = None) -> List[str]:
+def split_doc_comment_into_lines(cmt: str) -> List[str]:
     """Strip the raw string of an object's comment into lines.
     :param cmt: the comment to parse.
     :returns: A list of the lines without the surrounding C++ comment syntax.
@@ -524,7 +524,7 @@ def get_doc_comment(config: Config, cursor: Cursor):
                 break
             presumed_line = new_presumed_line
             if DOC_COMMENT_PREFIX.match(spelling) is not None:
-                comment_lines.extend(strip_comment(spelling))
+                comment_lines.extend(split_doc_comment_into_lines(spelling))
             got_line = True
             break
         if stop or not got_line:

--- a/sphinx_immaterial/apidoc/cpp/apigen.py
+++ b/sphinx_immaterial/apidoc/cpp/apigen.py
@@ -44,8 +44,10 @@ class ApigenConfig:
     document_prefix: str
     """Sphinx document path prefix for the per-entity documentation pages.
 
-    Because this is used as a Regular Expression pattern, this should end in
-    (and exclusively use) the Linux path separator :python:`"/"` (even if building on Windows).
+    .. important::
+        Because this is used as a Regular Expression pattern, this should end in
+        (and exclusively use) the Linux path separator :python:`"/"` (even if
+        building on Windows).
     """
 
     api_parser_config: Optional[api_parser.Config] = None

--- a/sphinx_immaterial/apidoc/cpp/apigen.py
+++ b/sphinx_immaterial/apidoc/cpp/apigen.py
@@ -52,13 +52,13 @@ class ApigenConfig:
     api_parser_config: Optional[api_parser.Config] = None
     """Configuration for generating an API description.
 
-    This option and :py:attr:`api_data` are mutually exclusive.
+    This option and `.api_data` are mutually exclusive.
     """
 
     api_data: Optional[str] = None
     """Path to already-parsed API description.
 
-    This option and :py:attr:`api_parser_config` are mutually exclusive.
+    This option and `.api_parser_config` are mutually exclusive.
     """
 
 

--- a/sphinx_immaterial/apidoc/cpp/apigen.py
+++ b/sphinx_immaterial/apidoc/cpp/apigen.py
@@ -44,19 +44,20 @@ class ApigenConfig:
     document_prefix: str
     """Sphinx document path prefix for the per-entity documentation pages.
 
-    This should end in :python:`"/"`.
+    Because this is used as a Regular Expression pattern, this should end in
+    (and exclusively use) the Linux path separator :python:`"/"` (even if building on Windows).
     """
 
     api_parser_config: Optional[api_parser.Config] = None
     """Configuration for generating an API description.
 
-    This option and `api_data` are mutually exclusive.
+    This option and :py:attr:`api_data` are mutually exclusive.
     """
 
     api_data: Optional[str] = None
     """Path to already-parsed API description.
 
-    This option and `api_parser_config` are mutually exclusive.
+    This option and :py:attr:`api_parser_config` are mutually exclusive.
     """
 
 

--- a/sphinx_immaterial/apidoc/cpp/apigen.py
+++ b/sphinx_immaterial/apidoc/cpp/apigen.py
@@ -50,13 +50,13 @@ class ApigenConfig:
     api_parser_config: Optional[api_parser.Config] = None
     """Configuration for generating an API description.
 
-    This option and `.api_data` are mutually exclusive.
+    This option and `api_data` are mutually exclusive.
     """
 
     api_data: Optional[str] = None
     """Path to already-parsed API description.
 
-    This option and `.api_parser_config` are mutually exclusive.
+    This option and `api_parser_config` are mutually exclusive.
     """
 
 

--- a/sphinx_immaterial/apidoc/cpp/apigen.py
+++ b/sphinx_immaterial/apidoc/cpp/apigen.py
@@ -45,8 +45,7 @@ class ApigenConfig:
     """Sphinx document path prefix for the per-entity documentation pages.
 
     .. important::
-        Because this is used as a Regular Expression pattern, this should end in
-        (and exclusively use) the Linux path separator :python:`"/"` (even if
+        This should use the Linux path separator :python:`"/"` (even if
         building on Windows).
     """
 

--- a/tests/cpp_api_parser_test.py
+++ b/tests/cpp_api_parser_test.py
@@ -70,7 +70,7 @@ class TestCommentStrip:
                 b"int var = 0;",
             ]
         )
-        self.assert_output("This is a docstring.")
+        self.assert_output(" This is a docstring.")
 
     def test2(self):
         self.config.input_content = b"\n".join(
@@ -79,7 +79,7 @@ class TestCommentStrip:
                 b"int var = 0;",
             ]
         )
-        self.assert_output("This is a docstring.")
+        self.assert_output(" This is a docstring.")
 
     def test3(self):
         self.config.input_content = b"\n".join(
@@ -88,7 +88,7 @@ class TestCommentStrip:
                 b"int var = 0;",
             ]
         )
-        self.assert_output("This is a docstring.")
+        self.assert_output(" This is a docstring.")
 
     def test4(self):
         self.config.input_content = b"\n".join(
@@ -97,7 +97,7 @@ class TestCommentStrip:
                 b"int var = 0;",
             ]
         )
-        self.assert_output("This is a docstring.")
+        self.assert_output(" This is a docstring.")
 
     def test5(self):
         self.config.input_content = b"\n".join(
@@ -105,7 +105,7 @@ class TestCommentStrip:
                 b"int var = 0; ///< This is a docstring.",
             ]
         )
-        self.assert_output("This is a docstring.")
+        self.assert_output(" This is a docstring.")
 
     def test6(self):
         self.config.input_content = b"\n".join(

--- a/tests/cpp_api_parser_test.py
+++ b/tests/cpp_api_parser_test.py
@@ -12,7 +12,8 @@ def test_basic():
 /// This is the doc.
 int foo(bool x, int y);
 
-""")
+""",
+    )
 
     output = api_parser.generate_output(config)
     entities = list(output["entities"].values())
@@ -41,7 +42,8 @@ int foo(T x);
         allow_paths=[re.escape(input_path)],
         disallow_namespaces=[re.compile("^std$")],
         compiler_flags=["-std=c++17"],
-        input_content=input_content)
+        input_content=input_content,
+    )
 
     output = api_parser.generate_output(config)
 
@@ -49,3 +51,78 @@ int foo(T x);
     assert len(entities) == 1
     requires = entities[0].get("requires")
     assert requires
+
+
+def test_comment_strip():
+    # this test can also be used for trailing doc strings (though it isn't supported yet)
+    config = api_parser.Config(
+        input_path="a.cpp",
+        input_content="""
+//! This is a docstring.
+int var = 0;
+
+/// This is a docstring.
+int arr[1];
+
+// Do not show this.
+bool internal = true;  ///< This is a docstring.
+
+/** This is a docstring. */
+bool is_used = false;
+
+/*! This is a docstring. */
+bool is_useful = false;
+""",
+    )
+
+    output = api_parser.generate_output(config)
+    doc_strings = [
+        v["doc"]["text"] for v in output.get("entities", {}).values()
+    ]
+    assert "Do not show this." not in doc_strings
+    # count changes to 5 when supporting trailing doc strings
+    assert doc_strings.count("This is a docstring.") >= 4
+
+def test_function_fields():
+    config = api_parser.Config(
+        input_path="a.cpp",
+        input_content="""
+/// @brief A dummy function for tests.
+///
+/// \\details A more detailed paragraph.
+///
+/// @param arg1 An arg passed by value.
+/// \\param[in] arg2 An unaltered arg passed by reference.
+/// @param[in, out] arg3 An arg passed by reference that gets altered.
+/// @retval int A negative number indicating a specific error, otherwise 0.
+/// @returns A flag indicating success.
+/// \\tparam T A template parameter.
+template<typename T>
+int function(T arg1, T &arg2, T &arg3);
+"""
+    )
+
+    output = api_parser.generate_output(config)
+    entities = output.get("entities", {})
+    doc_str = ""
+    for entity in entities.values():  # type: dict
+        if entity.get("doc"):
+            doc_str = entity["doc"]["text"]
+            break
+    else:
+        raise AttributeError("no doc string found.")
+    expected = "\n".join(
+        [
+            "A dummy function for tests.",
+            "",
+            "A more detailed paragraph.",
+            "",
+            ":param arg1: An arg passed by value.",
+            ":param arg2[in]: An unaltered arg passed by reference.",
+            ":param arg3[in, out]: An arg passed by reference that gets altered.",
+            ":retval int: A negative number indicating a specific error, otherwise 0.",
+            ":returns: A flag indicating success.",
+            ":tparam T: A template parameter.",
+        ]
+    )
+    assert expected == doc_str

--- a/tests/cpp_api_parser_test.py
+++ b/tests/cpp_api_parser_test.py
@@ -95,6 +95,17 @@ class TestCommentStrip:
                 "This is a docstring.",
             ),
         ],
+        ids=[
+            "///",
+            "//!",
+            "/**",
+            "/*!",
+            "///<",
+            "/** \n * \n */",
+            "/*! \n * \n */",
+            "// \n /// \n //",
+            "/* \n * \n */\n /** */\n /* */",
+        ],
     )
     def test_comment_styles(self, doc_str: bytes, expected: str):
         self.config.input_content = doc_str


### PR DESCRIPTION
Includes
- fix for Windows paths
- fix for unresolved cross-refs in the new docs
- support for `\` and `@` prefixed Doxygen commands
- support for `@retval` command
- support for param direction(s)
- add new `strip_comment()` to accommodate for all forms of C++ comment syntax

I also enabled verbosity in the cpp.apigen demo and added a line that shows the number of declarations that will be parsed.