### PR TITLE
Fix #121 (top border in hamburger menu for active item)

### DIFF
--- a/src/assets/stylesheets/main/layout/_nav.scss
+++ b/src/assets/stylesheets/main/layout/_nav.scss
@@ -233,6 +233,7 @@
         position: static;
         z-index: auto;
         background-color: transparent;
+        box-shadow: none;
       }
 
       // Navigation title and item


### PR DESCRIPTION
The top border was hidden by the outline created by the drop-shadow.
The drop shadow was only intended for the sidebar.