### PR TITLE
Python apigen: Ensure correct `module` is specified

### DIFF
--- a/sphinx_immaterial/apidoc/python/apigen.py
+++ b/sphinx_immaterial/apidoc/python/apigen.py
@@ -1505,6 +1505,8 @@ class _ApiEntityCollector:
 
         split_result = _split_autodoc_rst_output(rst_strings)
 
+        split_result.options.pop("module", None)
+
         overload_id: Optional[str] = None
         if entry.overload is not None:
             overload_id = entry.overload.overload_id
@@ -1628,8 +1630,10 @@ def _assign_documented_full_names(
             # Parent is a module.
             parent_documented_name = parent_ref.parent_canonical_object_name
             entity.top_level = True
+            entity.options["module"] = parent_ref.parent_canonical_object_name
         else:
             parent_documented_name = get_documented_full_name(parent_entity)
+            entity.options["module"] = parent_entity.options["module"]
         documented_full_name = parent_documented_name + "." + parent_ref.name
         entity.documented_full_name = documented_full_name
         entity.documented_name = parent_ref.name

--- a/tests/python_apigen_test.py
+++ b/tests/python_apigen_test.py
@@ -80,3 +80,21 @@ def test_classmethod(apigen_make_app):
     assert data.entities[f"{testmod}.Foo.my_method"].group_name == "Methods"
     assert data.entities[f"{testmod}.Foo.my_staticmethod"].group_name == "Methods"
     assert data.entities[f"{testmod}.Foo.my_classmethod"].group_name == "Methods"
+
+
+def test_issue_147(apigen_make_app):
+    testmod = "python_apigen_test_modules.issue147"
+    app = apigen_make_app(
+        confoverrides=dict(
+            python_apigen_modules={
+                testmod: "api/",
+            },
+        ),
+    )
+    print(app._status.getvalue())
+    print(app._warning.getvalue())
+
+    data = _get_api_data(app.env)
+
+    for entity in data.entities.values():
+        assert entity.options["module"] == testmod

--- a/tests/python_apigen_test_modules/_alpha.py
+++ b/tests/python_apigen_test_modules/_alpha.py
@@ -1,0 +1,23 @@
+from ._bravo import Bravo
+
+class Alpha(Bravo):
+    """
+    Class Alpha docstring.
+    """
+
+    def my_method_Alpha(self) -> int:
+        """
+        This is my_method_Alpha.
+
+        This is paragraph two.
+        """
+        pass
+
+    @property
+    def my_property_Alpha(self) -> str:
+        """
+        This is my_property_Alpha.
+
+        This is paragraph two.
+        """
+        pass

--- a/tests/python_apigen_test_modules/_bravo.py
+++ b/tests/python_apigen_test_modules/_bravo.py
@@ -1,0 +1,21 @@
+class Bravo:
+    """
+    Class Bravo docstring.
+    """
+
+    def my_method_Bravo(self) -> int:
+        """
+        This is my_method_Bravo.
+
+        This is paragraph two.
+        """
+        pass
+
+    @property
+    def my_property_Bravo(self) -> str:
+        """
+        This is my_property_Bravo.
+
+        This is paragraph two.
+        """
+        pass

--- a/tests/python_apigen_test_modules/issue147.py
+++ b/tests/python_apigen_test_modules/issue147.py
@@ -1,0 +1,2 @@
+from ._alpha import Alpha
+from ._bravo import Bravo


### PR DESCRIPTION
Fixes #147.