### PR TITLE
update typing related to the cpp.apigen ext

### DIFF
--- a/sphinx_immaterial/apidoc/cpp/fix_cpp_domain_symbol_resolution_through_type_aliases.py
+++ b/sphinx_immaterial/apidoc/cpp/fix_cpp_domain_symbol_resolution_through_type_aliases.py
@@ -37,6 +37,7 @@ def _monkey_patch_cpp_domain_symbol_resolution_through_type_aliases():
             nested_name = trailing_type_spec.name
         else:
             return None
+        assert self.parent is not None
         symbols, failReason = self.parent.find_name(
             nested_name,
             templateDecls=[],

--- a/sphinx_immaterial/apidoc/cpp/parameter_objects.py
+++ b/sphinx_immaterial/apidoc/cpp/parameter_objects.py
@@ -106,6 +106,7 @@ def get_precise_template_parameter_object_type(
     if object_type == "templateParam":
         # Determine more precise object type.
         if symbol is not None:
+            assert symbol.declaration is not None
             if isinstance(
                 symbol.declaration.declaration,
                 sphinx.domains.cpp.ASTTemplateParamNonType,

--- a/sphinx_immaterial/apidoc/cpp/symbol_ids.py
+++ b/sphinx_immaterial/apidoc/cpp/symbol_ids.py
@@ -38,6 +38,7 @@ def get_symbol_anchor(
 ) -> str:
     anchor = getattr(symbol.declaration, ANCHOR_ATTR, None)
     if anchor is None:
+        assert symbol.declaration is not None
         anchor = symbol.declaration.get_newest_id()
     return anchor
 

--- a/sphinx_immaterial/apidoc/object_description_options.py
+++ b/sphinx_immaterial/apidoc/object_description_options.py
@@ -4,6 +4,7 @@ from typing import List, Tuple, Pattern, Dict, Any, Optional, NamedTuple
 
 import pydantic
 import sphinx.application
+import sphinx.environment
 import sphinx.util.logging
 
 logger = sphinx.util.logging.getLogger(__name__)
@@ -146,7 +147,9 @@ def add_object_description_option(
 
 
 def get_object_description_options(
-    env: sphinx.environment.BuildEnvironment, domain: str, object_type: str
+    env: Optional[sphinx.environment.BuildEnvironment],
+    domain: Optional[str],
+    object_type: Optional[str],
 ) -> ObjectDescriptionOptions:
 
     return env.app._sphinx_immaterial_get_object_description_options(  # type: ignore

--- a/sphinx_immaterial/apidoc/object_toc.py
+++ b/sphinx_immaterial/apidoc/object_toc.py
@@ -4,6 +4,7 @@ from typing import cast, Optional, Union, Any, List
 import docutils.nodes
 import sphinx.addnodes
 import sphinx.application
+import sphinx.directives
 from sphinx.environment.collectors.toctree import TocTreeCollector
 from sphinx.locale import _
 

--- a/sphinx_immaterial/apidoc/python/object_ids.py
+++ b/sphinx_immaterial/apidoc/python/object_ids.py
@@ -110,14 +110,16 @@ def _monkey_patch_python_domain_to_support_object_ids():
                     strip_object_entry_node_id(orig_node_id, canonical_name)
 
                 if noindexentry:
-                    entries = self.indexnode["entries"]
+                    entries = cast(docutils.nodes.Element, self.indexnode)["entries"]
                     new_entries = []
                     for entry in entries:
                         new_entry = list(entry)
                         if new_entry[2] == orig_node_id:
                             new_entry[2] = ""
                         new_entries.append(tuple(new_entry))
-                    self.indexnode["entries"] = new_entries
+                    cast(docutils.nodes.Element, self.indexnode)[
+                        "entries"
+                    ] = new_entries
 
     PyObject.after_content = after_content
 


### PR DESCRIPTION
Looks like the latest release of Sphinx (v5.2.2) brought with it a few "tweaks" to their type hints.

This addresses just that.