### PR TITLE
Fix 168

### DIFF
--- a/sphinx_immaterial/graphviz.py
+++ b/sphinx_immaterial/graphviz.py
@@ -50,12 +50,12 @@ def _replace_resolved_xrefs(node: sphinx.ext.graphviz.graphviz, code: str) -> st
             else:
                 url = "#" + ref_node["refid"]
             title = ref_node.get("reftitle")
-            replacement_text += f', href="{url}"'
+            replacement_text += f' href="{url}"'
             if title is not None:
-                replacement_text += f", tooltip=<{html.escape(title)}>"
+                replacement_text += f" tooltip=<{html.escape(title)}>"
             target = ref_node.get("target")
             if target is not None:
-                replacement_text += f', target="{target}"'
+                replacement_text += f' target="{target}"'
 
         ref_replacements[xref_id] = replacement_text
 

--- a/tests/graphviz_test.py
+++ b/tests/graphviz_test.py
@@ -1,0 +1,60 @@
+"""Tests related to theme's patched graphviz ext."""
+import pytest
+from sphinx.testing.util import SphinxTestApp
+
+WITH_BRACKETS = """
+.. graphviz::
+
+    graph {
+        "foo()" [xref=":py:func:`foo()`"]
+    }
+
+"""
+
+WITHOUT_BRACKETS = """
+.. graphviz::
+
+    graph {
+        subgraph cluster_foo {
+            xref=":py:func:`foo()`"
+            A_node
+        }
+    }
+
+"""
+
+
+@pytest.mark.parametrize(
+    "graph", [WITH_BRACKETS, WITHOUT_BRACKETS], ids=["with", "without"]
+)
+def test_square_brackets(immaterial_make_app, graph: str):
+    """generate a graph with attributes not enclosed in square brackets"""
+    app: SphinxTestApp = immaterial_make_app(
+        extra_conf="\n".join(
+            [
+                'extensions.append("sphinx_immaterial.graphviz")',
+                # tests also run on Windows in CI
+                "graphviz_ignore_incorrect_font_metrics = True",
+            ]
+        ),
+        files={
+            "index.rst": """
+The Test
+========
+
+A function
+----------
+
+.. py:function:: foo()
+
+A graph
+-------
+
+{}""".format(
+                graph
+            )
+        },
+    )
+
+    app.build()
+    assert not app._warning.getvalue()


### PR DESCRIPTION
resolves #168 

This basically removes the commas from the substituted attributes ( triggered by xref attribute) and adds a couple unit tests to make sure the dot executable doesn't error out.

I have also visually verified that the graphs generated in the test are as expected. There might be a better way to inspect the SVG output, but I'd prefer to do that with a generated SVG file; this theme's graphviz ext embeds SVG data directly into the HTML for good reasons.