### PR TITLE
Minor doc updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -173,6 +173,7 @@ html_theme_options = {
         {
             "icon": "fontawesome/brands/github",
             "link": "https://github.com/jbms/sphinx-immaterial",
+            "name": "Source on github.com",
         },
         {
             "icon": "fontawesome/brands/python",

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -583,7 +583,7 @@ Configuration Options
         - The :python:`"icon"` field can be specifed as `any of the icons bundled with this theme`_
         - The :python:`"link"` field is simply the hyperlink target added to the icon specified.
         
-        Optionally, custom text used for the icon's tooltip by specifying a :python:`"name"`
+        Optionally, custom text may be specified for the icon's tooltip with the :python:`"name"`
         field. If the :python:`"name"` is not specified, then the domain of the :python:`"link"`
         is used automatically.
 

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -680,8 +680,8 @@ There are two approaches:
 
    .. warning::
        The JSON approach only works if your documentation is served from a webserver; it does not
-       work if you use ``file://`` url). When serving the docs from a webserver the
-       :themeconf:`version_json` file is resolved relative to the *parent* directory that contains
+       work if you use ``file://`` url. When serving the docs from a webserver the
+       :themeconf:`version_json` file is resolved relative to the directory that contains
        the sphinx builder's HTML output. For example, if the builder's output is ``2.0``, you
        should have directory structure like so:
 

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -582,6 +582,10 @@ Configuration Options
 
         - The :python:`"icon"` field can be specifed as `any of the icons bundled with this theme`_
         - The :python:`"link"` field is simply the hyperlink target added to the icon specified.
+        
+        Optionally, custom text used for the icon's tooltip by specifying a :python:`"name"`
+        field. If the :python:`"name"` is not specified, then the domain of the :python:`"link"`
+        is used automatically.
 
         .. literalinclude:: conf.py
             :caption: This theme uses the following configuration:


### PR DESCRIPTION
I found in the partials/social.html template that social links can have a customized tooltip using a `name` field. This adds the relevant info and demos its usage in the docs.

Also resolves #148 by removing a confusing adjective (per user feedback).