### PR TITLE
Fix 164

### DIFF
--- a/docs/graphviz.rst
+++ b/docs/graphviz.rst
@@ -137,7 +137,7 @@ Overriding the cross-reference label
 The :graphvizattr:`label` generated with the new ``xref`` attribute uses escaped HTML characters.
 In some graphs, it is preferable to use unescaped HTML characters in the :graphvizattr:`label`.
 In this case, the generated :graphvizattr:`label` can be overridden by manually specifying the
-:graphvizattr:`label` immediately after the ``xref`` attribute.
+:graphvizattr:`label` after the ``xref`` attribute.
 
 .. rst-example:: A graph of "record" nodes
    
@@ -178,5 +178,5 @@ In this case, the generated :graphvizattr:`label` can be overridden by manually 
 .. admonition:: Implementation note
    :class: info
 
-   Using cross references in a single field of a record node (with multiple fields) is unsupported
+   Using a cross reference in a single field of a record node (with multiple fields) is unsupported
    because the manually specified :graphvizattr:`label` is used as is.

--- a/docs/graphviz.rst
+++ b/docs/graphviz.rst
@@ -123,10 +123,60 @@ example above.
 The reStructuredText will be parsed, and after resolving any cross references,
 will be substituted back into the graph definition as follows:
 
-- A :graphvizattr:`label` will be generated from the text content.
-- If there is at least one ``reference`` node, only the last such node is
+- A :graphvizattr:`label` will be generated from the cross reference's text content.
+- If there is at least one cross referable target, only the last such target is
   considered, and:
 
   - an :graphvizattr:`href` will be generated from its URL.
   - a :graphvizattr:`tooltip` will be generated from its title/tooltip, if any.
   - a :graphvizattr:`target` will be generated from its target, if any.
+
+Overriding the cross-reference label
+************************************
+
+The :graphvizattr:`label` generated with the new ``xref`` attribute uses escaped HTML characters.
+In some graphs, it is preferable to use unescaped HTML characters in the :graphvizattr:`label`.
+In this case, the generated :graphvizattr:`label` can be overridden by manually specifying the
+:graphvizattr:`label` immediately after the ``xref`` attribute.
+
+.. rst-example:: A graph of "record" nodes
+   
+   .. graphviz::
+
+      digraph {
+          graph [rankdir = "LR"]
+          "module" [
+              xref=":py:mod:`test_py_module.test`"
+              label="<f0> test_py_module.test | <f1> functions | <f2> classes"
+              shape = "record"
+          ]
+          "class" [
+              xref = ":py:class:`test_py_module.test.Foo`"
+              label = "<f0> Foo | <f1> attributes | <f2> methods"
+              shape = "record"
+          ]
+          "method" [
+              xref = ":py:meth:`test_py_module.test.Foo.capitalize()`"
+              label = "<f0> capitalize() | <f1> variables"
+              shape = "record"
+          ]
+          "function" [
+              xref = ":py:func:`test_py_module.test.func()`"
+              label = "<f0> func() | <f1> variables"
+              shape = "record"
+          ]
+          "class_attr" [
+              xref = ":py:attr:`~test_py_module.test.Foo.spam`"
+              shape = "record"
+          ]
+          "module":f2 -> "class":f0
+          "module":f1 -> "function":f0
+          "class":f2 -> "method":f0
+          "class":f1 -> "class_attr"
+      }      
+
+.. admonition:: Implementation note
+   :class: info
+
+   Using cross references in a single field of a record node (with multiple fields) is unsupported
+   because the manually specified :graphvizattr:`label` is used as is.

--- a/docs/graphviz.rst
+++ b/docs/graphviz.rst
@@ -120,11 +120,11 @@ This extension adds support for a special ``xref`` attribute, which may be set
 to a string value containing reStructuredText.  This is demonstrated in the
 example above.
 
-The reStructuredText will be parsed, and after resolving any cross references,
+The reStructuredText will be parsed as a document fragment, and after resolving any cross references,
 will be substituted back into the graph definition as follows:
 
-- A :graphvizattr:`label` will be generated from the cross reference's text content.
-- If there is at least one cross referable target, only the last such target is
+- A :graphvizattr:`label` will be generated from the parsed fragment's text content.
+- If the parsed fragment contains at least one hyperlink, only the last such hyperlink is
   considered, and:
 
   - an :graphvizattr:`href` will be generated from its URL.
@@ -134,45 +134,48 @@ will be substituted back into the graph definition as follows:
 Overriding the cross-reference label
 ************************************
 
-The :graphvizattr:`label` generated with the new ``xref`` attribute uses escaped HTML characters.
+The :graphvizattr:`label` generated with the new ``xref`` attribute uses graphviz' HTML-like
+attribute syntax, but any HTML characters found within the ``xref`` parsed fragments' text are
+escaped (eg. ``< f0 >`` becomes ``&lt; f0 &gt;``).
 In some graphs, it is preferable to use unescaped HTML characters in the :graphvizattr:`label`.
 In this case, the generated :graphvizattr:`label` can be overridden by manually specifying the
 :graphvizattr:`label` after the ``xref`` attribute.
 
-.. rst-example:: A graph of "record" nodes
+.. rst-example:: A graph of record nodes
    
    .. graphviz::
 
       digraph {
           graph [rankdir = "LR"]
-          "module" [
+          module [
               xref=":py:mod:`test_py_module.test`"
               label="<f0> test_py_module.test | <f1> functions | <f2> classes"
-              shape = "record"
+              shape = record
           ]
-          "class" [
+          class [
               xref = ":py:class:`test_py_module.test.Foo`"
               label = "<f0> Foo | <f1> attributes | <f2> methods"
-              shape = "record"
+              shape = record
           ]
-          "method" [
+          method [
               xref = ":py:meth:`test_py_module.test.Foo.capitalize()`"
               label = "<f0> capitalize() | <f1> variables"
-              shape = "record"
+              shape = record
           ]
-          "function" [
+          function [
               xref = ":py:func:`test_py_module.test.func()`"
               label = "<f0> func() | <f1> variables"
-              shape = "record"
+              shape = record
           ]
-          "class_attr" [
-              xref = ":py:attr:`~test_py_module.test.Foo.spam`"
-              shape = "record"
+          class_attr [
+              // NOTE: cannot adequately angle brackets in xref's text
+              xref = ":py:attr:`spam | object <test_py_module.test.Foo.spam>`"
+              shape = record
           ]
-          "module":f2 -> "class":f0
-          "module":f1 -> "function":f0
-          "class":f2 -> "method":f0
-          "class":f1 -> "class_attr"
+          module:f2 -> class:f0
+          module:f1 -> function:f0
+          class:f2 -> method:f0
+          class:f1 -> class_attr // edge will point toward center of class_attr
       }      
 
 .. admonition:: Implementation note

--- a/sphinx_immaterial/graphviz.py
+++ b/sphinx_immaterial/graphviz.py
@@ -27,7 +27,7 @@ def _replace_resolved_xrefs(node: sphinx.ext.graphviz.graphviz, code: str) -> st
     """Extracts any resolved references, and uses them to replace `xref`
     attributes in the DOT code.
     """
-    ref_replacements = {}
+    ref_replacements: Dict[str, str] = {}
 
     for child in node.children:
         if not isinstance(child, docutils.nodes.container):
@@ -59,9 +59,11 @@ def _replace_resolved_xrefs(node: sphinx.ext.graphviz.graphviz, code: str) -> st
 
         ref_replacements[xref_id] = replacement_text
 
-    if ref_replacements:
-        ref_pattern = "|".join(ref_replacements.keys())
-        code = re.sub(ref_pattern, lambda m: ref_replacements[m.group(0)], code)
+    for ref_id, replacement in ref_replacements.items():
+        next_attr = re.search(ref_id + "[\\s,;]*\\w+", code)
+        if next_attr is not None and next_attr.group(0).endswith("label"):
+            replacement = replacement[replacement.find(">") + 1 :].lstrip()
+        code = re.sub(ref_id, replacement, code)
     return code
 
 

--- a/sphinx_immaterial/graphviz.py
+++ b/sphinx_immaterial/graphviz.py
@@ -27,7 +27,7 @@ def _replace_resolved_xrefs(node: sphinx.ext.graphviz.graphviz, code: str) -> st
     """Extracts any resolved references, and uses them to replace `xref`
     attributes in the DOT code.
     """
-    ref_replacements: Dict[str, str] = {}
+    ref_replacements = {}
 
     for child in node.children:
         if not isinstance(child, docutils.nodes.container):
@@ -59,11 +59,9 @@ def _replace_resolved_xrefs(node: sphinx.ext.graphviz.graphviz, code: str) -> st
 
         ref_replacements[xref_id] = replacement_text
 
-    for ref_id, replacement in ref_replacements.items():
-        next_attr = re.search(ref_id + "[\\s,;]*\\w+", code)
-        if next_attr is not None and next_attr.group(0).endswith("label"):
-            replacement = replacement[replacement.find(">") + 1 :].lstrip()
-        code = re.sub(ref_id, replacement, code)
+    if ref_replacements:
+        ref_pattern = "|".join(ref_replacements.keys())
+        code = re.sub(ref_pattern, lambda m: ref_replacements[m.group(0)], code)
     return code
 
 


### PR DESCRIPTION
resolves #164 

Implementation requires the manually specified `label` attribute be ~immediately~ after the `xref` attribute. I didn't add any unit tests because the docs demonstrate the purpose without fail, but we can add tests for certain graph types or use cases as we come across them.
