### PR TITLE
patch visitor for production list directive

### DIFF
--- a/docs/additional_samples.rst
+++ b/docs/additional_samples.rst
@@ -260,22 +260,36 @@ Math
       \end{eqnarray}
 
 
-..
-   FIXME: Production lists currently do not work.
 
-   Production Lists
-   ================
+Production Lists
+================
 
-   .. rst-example::
+The following `productionlist` is a modified example taken from
+`the Graphviz documentation <https://graphviz.org/doc/info/lang.html>`_
 
-      .. productionlist::
-         try_stmt: try1_stmt | try2_stmt
-         try1_stmt: "try" ":" `suite`
-                  : ("except" [`expression` ["," `target`]] ":" `suite`)+
-                  : ["else" ":" `suite`]
-                  : ["finally" ":" `suite`]
-         try2_stmt: "try" ":" `suite`
-                  : "finally" ":" `suite`
+.. rst-example:: Grammar for dot syntax
+
+    .. productionlist::
+       graph      : [ strict ] (`graph` | digraph) [ ID ] '{' `stmt_list` '}'
+       stmt_list  : [ `stmt` [ ';' ] `stmt_list` ]
+       stmt       : `node_stmt`
+                  : `edge_stmt`
+                  : `attr_stmt`
+                  : ID '=' ID
+                  : `subgraph`
+       attr_stmt  : (`graph` | node | edge) `attr_list`
+       attr_list  : '[' [ `a_list` ] ']' [ `attr_list` ]
+       a_list     : ID '=' ID [ (';' | ',') ] [ `a_list` ]
+       edge_stmt  : (`node_id` | `subgraph`) `edgeRHS` [ `attr_list` ]
+       edgeRHS    : edgeop (`node_id` | `subgraph`) [ `edgeRHS` ]
+       node_stmt  : `node_id` [ `attr_list` ]
+       node_id    : ID [ `port` ]
+       port       : ':' ID [ ':' `compass_pt` ]
+                  : ':' `compass_pt`
+       subgraph   : [ `subgraph` [ ID ] ] '{' `stmt_list` '}'
+       compass_pt : (n | ne | e | se | s | sw | w | nw | c | _)
+
+    This is a reference to the grammar for a :token:`graph` in dot syntax.
 
 Sub-pages
 =========

--- a/sphinx_immaterial/apidoc/apidoc_formatting.py
+++ b/sphinx_immaterial/apidoc/apidoc_formatting.py
@@ -122,6 +122,27 @@ def depart_desc_inline(
     self.body.append("</code>")
 
 
+@html_translator_mixin.override
+def visit_productionlist(
+    self: html_translator_mixin.HTMLTranslatorMixin,
+    node: sphinx.addnodes.productionlist,
+    super_func: html_translator_mixin.BaseVisitCallback[sphinx.addnodes.productionlist],
+):
+    # we only need to patch in a code element around the production list
+    before_len = len(self.body)
+    try:
+        super_func(self, node)
+    except docutils.nodes.SkipNode:
+        pass
+    # be sure that there wasn't an incompatible change to sphinx
+    assert self.body[before_len].endswith("<pre>\n") and self.body[-1].startswith(
+        "</pre>"
+    )
+    self.body[before_len] += "<code>"
+    self.body[-1] = "</code>" + self.body[-1]
+    raise docutils.nodes.SkipNode()
+
+
 @html_translator_mixin.init
 def init_translator(self: html_translator_mixin.HTMLTranslatorMixin) -> None:
 


### PR DESCRIPTION
Also un-comment the section in additional_samples.rst now that this patch addresses #46

Modified the production list example to use dot syntax grammar (and avoid unreferenced token warnings in the build log). I added use of the `:token:` role in production list example to better demonstrate the full utility of a production list.