### PR TITLE
doc use of Giscus; add comments meta data tag

### DIFF
--- a/sphinx_immaterial/nav_adapt.py
+++ b/sphinx_immaterial/nav_adapt.py
@@ -801,6 +801,8 @@ def _html_page_context(
         page["meta"]["hide"].append("footer")
     if "hide-feedback" in meta:
         page["meta"]["hide"].append("feedback")
+    if "show-comments" in meta:
+        page["meta"]["comments"] = True
     if context.get("next"):
         page["next_page"] = {
             "title": markupsafe.Markup.escape(


### PR DESCRIPTION
Allows integration of page comments using [giscus](https://giscus.app/) (which uses github's discussions feature). Only thing we needed was a `comments` meta data field to enable comments for a specific page. Everything else is done by the user in the docs project's template overrides, which is now documented with instructions in customization.rst.

Tested this on a separate repo of mine (hosted at RTD.org), and it seems to work. It will not work when the URL is a `file://`. So, there's a preview at the bottom of [this page](https://circuitpython-homie.readthedocs.io/en/trying-doc-comments/tutorials/openhab.html#adding-a-homie-dev-as-an-oh-thing).
