### PR TITLE
adjust regressive z-index override from #171

### DIFF
--- a/src/assets/stylesheets/main/layout/_nav.scss
+++ b/src/assets/stylesheets/main/layout/_nav.scss
@@ -678,7 +678,7 @@
           > .md-nav__link {
             position: sticky;
             top: 0;
-            z-index: 1;
+            z-index: var(--md-nav__sticky-zindex, 1);
             margin-top: 0;
             padding: 0 px2rem(12px);
             font-weight: 700;


### PR DESCRIPTION
fixes #189 by using the inline CSS variable with fallback value inherited from upstream