### PR TITLE
Fix #196 exception in MyST/markdown-it-py

### DIFF
--- a/sphinx_immaterial/custom_admonitions.py
+++ b/sphinx_immaterial/custom_admonitions.py
@@ -182,7 +182,8 @@ class CustomAdmonitionDirective(Directive, ABC):
             title_text += (" " if title_text else "") + self.options["title"]
             # don't auto-assert `:no-title:` if value is blank; just use default
         if not title_text:
-            title_text = self.default_title
+            # title_text must be an explicit string for renderers like MyST
+            title_text = str(self.default_title)
         self.assert_has_content()
         admonition_node = self.node_class("\n".join(self.content), **self.options)  # type: ignore[call-arg]
         (


### PR DESCRIPTION
For the `markdown_it` module used by `myst_parser` the text must be passed as explicit string.

This PR ensures the `title_text` from `self.default_title` in `custom_admonitions.py` is converted from `<class 'sphinx.locale._TranslationProxy'>` to string.

This PR fixed #196.