### PR TITLE
Fix to use ts-graphviz/setup-graphviz again on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,18 +36,9 @@ jobs:
         path: "**/node_modules"
         key: ${{ runner.os }}-${{ matrix.node-version }}-node_modules-${{ hashFiles('**/package-lock.json') }}
     - name: Setup Graphviz
-      run: |
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          sudo apt-get update && sudo apt-get install graphviz libgraphviz-dev pkg-config
-        elif [ "$RUNNER_OS" == "Windows" ]; then
-          choco install graphviz
-        elif [ "$RUNNER_OS" == "macOS" ]; then
-          brew install graphviz
-        else
-          echo "$RUNNER_OS not supported"
-          exit 1
-        fi
-      shell: bash
+      uses: ts-graphviz/setup-graphviz@v1.2.0
+      with:
+        macos-skip-brew-update: 'true'
     - run: npm install
     - run: npm run check
     - name: Install Python packaging, linting, & testing tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         path: "**/node_modules"
         key: ${{ runner.os }}-${{ matrix.node-version }}-node_modules-${{ hashFiles('**/package-lock.json') }}
     - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@v1.2.0
+      uses: ts-graphviz/setup-graphviz@c001ccfb5aff62e28bda6a6c39b59a7e061be5b9 # v1.2.0
       with:
         macos-skip-brew-update: 'true'
     - run: npm install


### PR DESCRIPTION
CI failed due to setup-graphviz behavior on macOS, so we no longer use ts-graphviz/setup-graphviz in PR #181.

In [ts-graphviz/setup-graphviz@v1.2.0](https://github.com/ts-graphviz/setup-graphviz/releases/tag/v1.2.0), this issue has been resolved and we are now using it again.