### PR TITLE
Improve CSS/JavaScript bundling and fix miscellaneous issues

### DIFF
--- a/docs/apidoc/python/index.rst
+++ b/docs/apidoc/python/index.rst
@@ -225,7 +225,6 @@ specified in the signature.
       Does something with an `int` or `float`.
 
    .. py:function:: overload_example2(a: str) -> str
-
       :object-ids: ["overload_example2(str)"]
 
       Does something with a `str`.
@@ -248,7 +247,7 @@ This theme extends the Python domain directives (as well as the corresponding
 ``auto<objtype>`` directives provided by the `sphinx.ext.autodoc` extension)
 with a ``:nonodeid:`` option:
 
-.. code-block:: python
+.. code-block:: rst
 
    .. py:function:: func(a: int) -> int
       :nonodeid:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -327,6 +327,8 @@ sphinx_immaterial_custom_admonitions = [
 # END CUSTOM ADMONITIONS
 sphinx_immaterial_icon_path = html_static_path
 
+sphinx_immaterial_bundle_source_maps = True
+
 
 jinja_contexts = {
     "sys": {"sys": sys},

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -209,13 +209,13 @@ Configuration Options
 
             .. important::
                 This option has no effect if the :themeconf:`repo_url` option is not specified.
-        
+
         .. themeconf:: admonition
 
             The default icons for admonitions can be changed by setting this field to a `dict` in
             which the keys are CSS classes (see :doc:`admonitions`) and the values are
             `any of the icons bundled with this theme`_.
-            
+
             .. seealso::
                 Refer to the :ref:`change_admonition_icon` section for more detail.
 
@@ -273,7 +273,7 @@ Configuration Options
         - `search.share <https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#search-sharing>`_
         - `toc.integrate <https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-integration>`_
         - `announce.dismiss <https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-header/?h=ann#mark-as-read>`_
-          
+
           .. seealso::
               Refer to the `New blocks`_ section below about how to add an announcement banner.
         - ``toc.follow``
@@ -441,7 +441,7 @@ Configuration Options
                     "property": "G-XXXXXXXXXX"
                 }
             }
-        
+
         .. themeconf:: feedback
 
             This theme also supports user feedback using site analytics. Along with the required
@@ -538,7 +538,7 @@ Configuration Options
 
         - The :python:`"icon"` field can be specifed as `any of the icons bundled with this theme`_
         - The :python:`"link"` field is simply the hyperlink target added to the icon specified.
-        
+
         Optionally, custom text may be specified for the icon's tooltip with the :python:`"name"`
         field. If the :python:`"name"` is not specified, then the domain of the :python:`"link"`
         is used automatically.
@@ -578,6 +578,12 @@ Configuration Options
    Environment variable that specifies a default value for the
    :confval:`sphinx_immaterial_external_resource_cache_dir` configuration
    option.
+
+.. confval:: sphinx_immaterial_bundle_source_maps
+
+   Write ``.css.map`` and ``.js.map`` source maps for the CSS and JavaScript
+   bundles to the output directory.  Source maps are helpful when developing the
+   theme.
 
 .. _version_dropdown:
 
@@ -803,13 +809,13 @@ There are several services that can deliver an integrated comment system, but th
 demonstrates using Giscus_ which is Open Source and built on Github's Discussions feature.
 
 1. Ensure these requisites are completed:
-   
+
    - Install the `Giscus Github App <https://github.com/apps/giscus>`_ and grant access to the
      repository that should host comments as GitHub discussions. Note that this can be a repository
      different from your documentation.
    - Visit Giscus_ and generate the snippet through their configuration tool to load the comment
      system. Copy the snippet for the next step. The resulting snippet should look similar to this:
-     
+
      .. code-block:: html
 
          <script
@@ -836,18 +842,18 @@ demonstrates using Giscus_ which is Open Source and built on Github's Discussion
        {% if page.meta.comments %} <!-- (1)! -->
          <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
          <!-- Insert generated snippet (2) here -->
-       
+
          <!-- Synchronize Giscus theme with palette -->
          <script>
            var giscus = document.querySelector("script[src*=giscus]")
-       
+
            /* Set palette on initial load */
            var palette = __md_get("__palette")
            if (palette && typeof palette.color === "object") {
              var theme = palette.color.scheme === "slate" ? "dark" : "light" // (3)!
              giscus.setAttribute("data-theme", theme)
            }
-       
+
            /* Register event handlers after documented loaded */
            document.addEventListener("DOMContentLoaded", function() {
              var ref = document.querySelector("[data-md-component=palette]")
@@ -855,7 +861,7 @@ demonstrates using Giscus_ which is Open Source and built on Github's Discussion
                var palette = __md_get("__palette")
                if (palette && typeof palette.color === "object") {
                  var theme = palette.color.scheme === "slate" ? "dark" : "light" // (3)!
-       
+
                  /* Instruct Giscus to change theme */
                  var frame = document.querySelector(".giscus-frame")
                  frame.contentWindow.postMessage(

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "docs": "npm run build && rimraf docs/_build && cd docs && sphinx-build . _build -a",
     "docs:dev": "npm run build:dev && rimraf docs/_build/* && cd docs && sphinx-build . _build -a",
     "docs:watch": "ts-node -T tools/build --verbose --dirty --watch --docs",
-    "clean": "rimraf sphinx_immaterial/{*.html,partials,.icons,static,LICENSE}",
+    "clean": "rimraf sphinx_immaterial/{*.html,partials,.icons,LICENSE,bundles}",
     "check": "run-p check:*",
     "check:build": "tsc --noEmit",
     "check:style": "run-p check:style:*",

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ class StaticBundlesCommand(setuptools.command.build_py.build_py):
         (
             "skip-rebuild",
             None,
-            "Skip rebuilding if the `sphinx_immaterial` directory already exists.",
+            "Skip rebuilding if the `sphinx_immaterial/bundles` directory already exists.",
         ),
     ]
 
@@ -136,7 +136,7 @@ class StaticBundlesCommand(setuptools.command.build_py.build_py):
 
     def run(self):
         if self.skip_rebuild:
-            output_dir = os.path.join(package_root, "static")
+            output_dir = os.path.join(package_root, "bundles")
             if os.path.exists(output_dir):
                 print(
                     "Skipping rebuild of package since %s already exists"
@@ -183,7 +183,6 @@ setuptools.setup(
             "partials/*/*.html",
             "partials/*/*/*.html",
             "partials/*/*/*/*.html",
-            "static/*/**",
             "bundles/*/**",
             "LICENSE",
             "*.html",

--- a/sphinx_immaterial/__init__.py
+++ b/sphinx_immaterial/__init__.py
@@ -63,6 +63,7 @@ def _get_html_builder(base_builder: Type[sphinx.builders.html.StandaloneHTMLBuil
                     "_static/doctools.js",
                     "_static/language_data.js",
                     "_static/documentation_options.js",
+                    "_static/sphinx_highlight.js",
                 ]
             )
             if nav_adapt.READTHEDOCS is None:
@@ -121,6 +122,7 @@ def _get_html_builder(base_builder: Type[sphinx.builders.html.StandaloneHTMLBuil
                             "**/basic.css_t",
                             "**/documentation_options.js_t",
                             "**/searchtools.js",
+                            "**/sphinx_highlight.js",
                         ]
                         if nav_adapt.READTHEDOCS is None:
                             excluded_list.append("**/jquery*.js")

--- a/sphinx_immaterial/__init__.py
+++ b/sphinx_immaterial/__init__.py
@@ -249,6 +249,7 @@ def setup(app: Sphinx):
     app.connect("config-inited", _config_inited)
 
     app.setup_extension("sphinx_immaterial.external_resource_cache")
+    app.setup_extension("sphinx_immaterial.google_fonts")
 
     app.setup_extension(apidoc_formatting.__name__)
     app.setup_extension("sphinx_immaterial.apidoc.python.default")

--- a/sphinx_immaterial/__init__.py
+++ b/sphinx_immaterial/__init__.py
@@ -248,6 +248,7 @@ def _config_inited(
 def setup(app: Sphinx):
     app.connect("config-inited", _config_inited)
 
+    app.setup_extension("sphinx_immaterial.css_and_javascript_bundles")
     app.setup_extension("sphinx_immaterial.external_resource_cache")
     app.setup_extension("sphinx_immaterial.google_fonts")
 

--- a/sphinx_immaterial/css_and_javascript_bundles.py
+++ b/sphinx_immaterial/css_and_javascript_bundles.py
@@ -1,0 +1,200 @@
+"""Bundles CSS and JavaScript resources."""
+
+import hashlib
+import json
+import os
+import pathlib
+from typing import NamedTuple, Optional, List
+
+import sphinx.application
+import sphinx.environment
+
+
+class Entry(NamedTuple):
+    code: str
+    sourcemap: Optional[str]
+    priority: int
+
+
+_CSS_KEY = "_sphinx_immaterial_global_css"
+_JAVASCRIPT_KEY = "_sphinx_immaterial_global_javascript"
+_BUNDLE_SOURCE_MAPS_KEY = "sphinx_immaterial_bundle_source_maps"
+
+
+def _get_css_entries(app: sphinx.application.Sphinx) -> List[Entry]:
+    entries = getattr(app, _CSS_KEY, None)
+    if entries is None:
+        entries = []
+        setattr(app, _CSS_KEY, entries)
+    return entries
+
+
+def _get_javascript_entries(app: sphinx.application.Sphinx) -> List[Entry]:
+    entries = getattr(app, _JAVASCRIPT_KEY, None)
+    if entries is None:
+        entries = []
+        setattr(app, _JAVASCRIPT_KEY, entries)
+    return entries
+
+
+def add_global_css(
+    app: sphinx.application.Sphinx,
+    code: str,
+    sourcemap: Optional[str] = None,
+    priority: int = 500,
+):
+    _get_css_entries(app).append(
+        Entry(code=code, sourcemap=sourcemap, priority=priority)
+    )
+
+
+def add_global_javascript(
+    app: sphinx.application.Sphinx,
+    code: str,
+    sourcemap: Optional[str] = None,
+    priority: int = 500,
+):
+    _get_javascript_entries(app).append(
+        Entry(code=code, sourcemap=sourcemap, priority=priority)
+    )
+
+
+def generate_bundle(
+    app: sphinx.application.Sphinx,
+    env: sphinx.environment.BuildEnvironment,
+    entries: List[Entry],
+    source_mapping_url_prefix: str,
+    source_mapping_url_suffix: str,
+    output_prefix: str,
+    output_ext: str,
+) -> str:
+    entries.sort(key=lambda e: e.priority)
+
+    # Use the special "sections" support in Source Map v3 to combine source maps
+    # without needing to decode them.
+    #
+    # https://sourcemaps.info/spec.html
+    sourcemap_sections = []
+    lines: List[str] = []
+
+    entries.sort(key=lambda entry: entry.priority)
+    for entry in entries:
+        entry_lines = [
+            x
+            for x in entry.code.rstrip().splitlines()
+            if not x.startswith(source_mapping_url_prefix)
+        ]
+        offset = len(lines)
+        lines.extend(entry_lines)
+        if entry.sourcemap:
+            sourcemap = json.loads(entry.sourcemap)
+            sourcemap_sections.append(
+                {"offset": {"line": offset, "column": 0}, "map": sourcemap}
+            )
+    lines.append("")
+    output_data = "\n".join(lines).encode("utf-8")
+
+    # hash data and write to generated file
+    output_data_hash = hashlib.sha256(output_data).hexdigest()
+    static_dir = pathlib.Path(app.outdir) / "_static"
+    output_path = f"{output_prefix}.{output_data_hash[:17]}.min.{output_ext}"
+    output_path_obj = static_dir / output_path
+    output_path_obj.parent.mkdir(parents=True, exist_ok=True)
+    if sourcemap_sections and getattr(app.config, _BUNDLE_SOURCE_MAPS_KEY):
+        sourcemap_path = output_path + ".map"
+        (static_dir / sourcemap_path).write_text(
+            json.dumps({"version": 3, "sections": sourcemap_sections}),
+            encoding="utf-8",
+        )
+        output_data += (
+            source_mapping_url_prefix
+            + os.path.basename(sourcemap_path)
+            + source_mapping_url_suffix
+            + "\n"
+        ).encode("utf-8")
+    output_path_obj.write_bytes(output_data)
+    return output_path
+
+
+def generate_bundles(
+    app: sphinx.application.Sphinx, env: sphinx.environment.BuildEnvironment
+) -> None:
+    """Bundles the theme CSS with any additional CSS added using `add_global_css`."""
+
+    css_entries = list(_get_css_entries(app))
+
+    # copy pre-minified CSS from theme's bundles
+    theme_bundles = pathlib.Path(__file__).parent / "bundles" / "stylesheets"
+    css_entries.append(
+        Entry(
+            code=(theme_bundles / "main.css").read_text(encoding="utf-8"),
+            sourcemap=(theme_bundles / "main.css.map").read_text(encoding="utf-8"),
+            priority=200,
+        )
+    )
+
+    theme_options = app.config["html_theme_options"]
+    if theme_options and "palette" in theme_options:
+        css_entries.append(
+            Entry(
+                code=(theme_bundles / "palette.css").read_text(encoding="utf-8"),
+                sourcemap=(theme_bundles / "palette.css.map").read_text(
+                    encoding="utf-8"
+                ),
+                priority=200,
+            )
+        )
+
+    css_bundle = generate_bundle(
+        app=app,
+        env=env,
+        entries=css_entries,
+        source_mapping_url_prefix="/*# sourceMappingURL=",
+        source_mapping_url_suffix=" */",
+        output_prefix="sphinx_immaterial_theme",
+        output_ext="css",
+    )
+    app.add_css_file(css_bundle, priority=200)
+
+    js_entries = list(_get_javascript_entries(app))
+    js_entries.append(
+        Entry(
+            code=(
+                pathlib.Path(__file__).parent / "bundles" / "javascripts" / "bundle.js"
+            ).read_text(encoding="utf-8"),
+            sourcemap=(
+                pathlib.Path(__file__).parent
+                / "bundles"
+                / "javascripts"
+                / "bundle.js.map"
+            ).read_text(encoding="utf-8"),
+            priority=200,
+        )
+    )
+
+    js_bundle = generate_bundle(
+        app=app,
+        env=env,
+        entries=js_entries,
+        source_mapping_url_prefix="//# sourceMappingURL=",
+        source_mapping_url_suffix="",
+        output_prefix="sphinx_immaterial_theme",
+        output_ext="js",
+    )
+    app.add_js_file(js_bundle, priority=200)
+
+
+def setup(app: sphinx.application.Sphinx):
+    app.connect("env-check-consistency", generate_bundles, priority=999)
+
+    app.add_config_value(
+        _BUNDLE_SOURCE_MAPS_KEY,
+        default=False,
+        rebuild="env",
+        types=(bool,),
+    )
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/sphinx_immaterial/custom_admonitions.py
+++ b/sphinx_immaterial/custom_admonitions.py
@@ -18,6 +18,7 @@ import sphinx.ext.todo
 from sphinx.locale import admonitionlabels, _
 from sphinx.util.logging import getLogger
 from sphinx.writers.html5 import HTML5Translator
+from .css_and_javascript_bundles import add_global_css
 from .inline_icons import load_svg_into_builder_env, get_custom_icons
 
 logger = getLogger(__name__)
@@ -312,14 +313,10 @@ def on_config_inited(app: Sphinx, config: Config):
             app.add_directive(admonition, get_directive_class(admonition, title), True)
 
 
-def consolidate_css(app: Sphinx, env: BuildEnvironment):
+def add_admonition_and_icon_css(app: Sphinx, env: BuildEnvironment):
     """Generates the CSS for icons and admonitions, then appends that to the
     theme's bundled CSS."""
 
-    theme_options = app.config["html_theme_options"]
-    is_palette_defined = False
-    if theme_options:
-        is_palette_defined = "palette" in theme_options
     custom_admonitions = getattr(env, _CUSTOM_ADMONITIONS_KEY)
     custom_icons = get_custom_icons(env)
 
@@ -332,26 +329,8 @@ def consolidate_css(app: Sphinx, env: BuildEnvironment):
         admonitions=custom_admonitions,
     )
 
-    css_data = io.BytesIO()
-    # copy pre-minified CSS from theme's bundles
-    theme_bundles = Path(__file__).parent / "bundles" / "stylesheets"
-    for bundle in theme_bundles.glob("*.min.css"):
-        if not is_palette_defined and bundle.name.startswith("palette"):
-            continue  # don't need the palette CSS if HTML doesn't need it
-        css_data.write(bundle.read_bytes())
-
     # append the generated CSS for icons and admonitions
-    css_data.write(generated.replace("\n", "").encode(encoding="utf-8"))
-
-    # hash CSS data and write to generated file
-    css_data_hash = hashlib.sha256(css_data.getvalue()).hexdigest()
-    css_name = f"stylesheets/sphinx_immaterial_theme.{css_data_hash[:17]}.min.css"
-    css_output = Path(app.outdir, "_static", css_name)
-    css_output.parent.mkdir(parents=True, exist_ok=True)
-    css_output.write_bytes(css_data.getvalue())
-
-    # ensure new CSS file is added in the rendered HTML output
-    app.add_css_file(css_name)
+    add_global_css(app, generated.replace("\n", ""))
 
 
 def setup(app: Sphinx):
@@ -382,7 +361,7 @@ def setup(app: Sphinx):
     )
 
     app.connect("builder-inited", on_builder_inited)
-    app.connect("env-check-consistency", consolidate_css)
+    app.connect("env-check-consistency", add_admonition_and_icon_css)
     app.connect("config-inited", on_config_inited)
 
     patch_visit_admonition()

--- a/sphinx_immaterial/custom_admonitions.py
+++ b/sphinx_immaterial/custom_admonitions.py
@@ -18,12 +18,14 @@ import sphinx.ext.todo
 from sphinx.locale import admonitionlabels, _
 from sphinx.util.logging import getLogger
 from sphinx.writers.html5 import HTML5Translator
-from .inline_icons import load_svg_into_builder_env
+from .inline_icons import load_svg_into_builder_env, get_custom_icons
 
 logger = getLogger(__name__)
 
 # treat the todo directive from the sphinx extension as a built-in directive
 admonitionlabels["todo"] = _("Todo")
+
+_CUSTOM_ADMONITIONS_KEY = "sphinx_immaterial_custom_admonitions"
 
 
 class CustomAdmonitionConfig(pydantic.BaseModel):
@@ -252,7 +254,6 @@ def on_builder_inited(app: Sphinx):
     custom_admonitions: List[CustomAdmonitionConfig] = getattr(
         config, "sphinx_immaterial_custom_admonitions"
     )
-    setattr(app.builder.env, "sphinx_immaterial_custom_icons", {})
     for admonition in custom_admonitions:
 
         app.add_directive(
@@ -319,9 +320,9 @@ def consolidate_css(app: Sphinx, env: BuildEnvironment):
     is_palette_defined = False
     if theme_options:
         is_palette_defined = "palette" in theme_options
+    custom_admonitions = getattr(env, _CUSTOM_ADMONITIONS_KEY)
+    custom_icons = get_custom_icons(env)
 
-    custom_admonitions = getattr(env, "sphinx_immaterial_custom_admonitions")
-    custom_icons = getattr(env, "sphinx_immaterial_custom_icons")
     jinja_env = jinja2.Environment(
         loader=jinja2.FileSystemLoader(str(PurePath(__file__).parent))
     )

--- a/sphinx_immaterial/external_resource_cache.py
+++ b/sphinx_immaterial/external_resource_cache.py
@@ -80,152 +80,9 @@ def _get_default_cache_dir(config: sphinx.config.Config):
 
 _RESOURCE_CONFIG_KEY = "sphinx_immaterial_external_resource_cache_dir"
 
-# https://stackoverflow.com/questions/25011533/google-font-api-uses-browser-detection-how-to-get-all-font-variations-for-font
-_FONT_FORMAT_USER_AGENT = {
-    "ttf": "Safari 3.1 Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_5_2; en-gb) AppleWebKit/526+ (KHTML, like Gecko) Version/3.1 iPhone",
-    "woff": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36",
-    # "Safari 6.0 Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25",
-    # 'woff2': 'Firefox 36.0 Mozilla/5.0 (Windows NT 6.3; rv:36.0) Gecko/20100101 Firefox/36.0',
-}
 
-
-_CSS_URL_PATTERN = re.compile(r"url\(([^\)]+)\)")
-
-_FILE_EXT_PATTERN = re.compile(r".*(\.[^\.]+)")
-
-
-def _extract_urls(css_content: bytes) -> Set[str]:
-    urls = set()
-    for m in _CSS_URL_PATTERN.finditer(css_content.decode("utf-8")):
-        urls.add(m.group(1))
-    return urls
-
-
-def _adjust_css_urls(css_content: bytes, renamed_fonts: Dict[str, str]) -> str:
-    css_text = css_content.decode("utf-8")
-    return _CSS_URL_PATTERN.sub(
-        lambda m: f"url(fonts/{renamed_fonts[m.group(1)]})", css_text
-    )
-
-
-_MAX_CONCURRENT_FETCHES = 128
-
-_TTF_FONT_PATHS_KEY = "sphinx_immaterial_ttf_font_paths"
-
-
-def add_google_fonts(app: sphinx.application.Sphinx, fonts: List[str]):
-
-    cache_dir = getattr(app.config, _RESOURCE_CONFIG_KEY)
-    static_dir = os.path.join(app.outdir, "_static")
-    # _static path
-    font_dir = os.path.join(static_dir, "fonts")
-    os.makedirs(font_dir, exist_ok=True)
-
-    with concurrent.futures.ThreadPoolExecutor(max_workers=32) as executor:
-
-        def to_thread(fn, *args, **kwargs) -> asyncio.Future:
-            return asyncio.wrap_future(executor.submit(fn, *args, **kwargs))
-
-        async def fetch_font(font: str, style: str):
-            css_url = f"https://fonts.googleapis.com/css?family={urllib.parse.quote(font)}:{style}"
-
-            css_content_future = asyncio.gather(
-                *[
-                    to_thread(
-                        get_url,
-                        cache_dir,
-                        css_url,
-                        headers={"user-agent": user_agent},
-                    )
-                    for user_agent in _FONT_FORMAT_USER_AGENT.values()
-                ]
-            )
-
-            css_content = dict(
-                zip(_FONT_FORMAT_USER_AGENT.keys(), await css_content_future)
-            )
-
-            font_files = set()
-            ttf_font_files = None
-
-            for font_format, css_data in css_content.items():
-                urls = _extract_urls(css_data)
-                font_files.update(urls)
-                if font_format == "ttf":
-                    ttf_font_files = urls
-
-            font_data_futures = asyncio.gather(
-                *[to_thread(get_url, cache_dir, font_url) for font_url in font_files]
-            )
-
-            all_font_data = dict(zip(font_files, await font_data_futures))
-
-            renamed_fonts = {}
-
-            for font_url, font_data in all_font_data.items():
-                h = hashlib.sha256(font_data).hexdigest()[:32]
-                m = _FILE_EXT_PATTERN.fullmatch(font_url)
-                if m is not None:
-                    file_ext = m.group(1)
-                else:
-                    file_ext = ""
-                new_name = h + file_ext
-                renamed_fonts[font_url] = new_name
-                with open(os.path.join(font_dir, new_name), "wb") as f:
-                    f.write(font_data)
-            adjusted_css_content = {
-                font_format: _adjust_css_urls(css_data, renamed_fonts)
-                for font_format, css_data in css_content.items()
-            }
-
-            ttf_font_path = None
-
-            if ttf_font_files is None or len(ttf_font_files) != 1:
-                logger.error(
-                    "Expected 1 TTF font for %s:%s but received: %r",
-                    font,
-                    style,
-                    css_content["ttf"],
-                )
-            else:
-                ttf_font_url = next(iter(ttf_font_files))
-                ttf_font_path = renamed_fonts[ttf_font_url]
-
-            return adjusted_css_content, ttf_font_path
-
-        async def do_fetch():
-            css_future_keys = []
-            css_futures = []
-            for font in fonts:
-                for style in ["300", "300i", "400", "400i", "700", "700i"]:
-                    css_future_keys.append((font, style))
-                    css_futures.append(fetch_font(font, style))
-            css_content = dict(zip(css_future_keys, await asyncio.gather(*css_futures)))
-            return css_content
-
-        css_content = asyncio.run(do_fetch())
-
-    # Write fonts css file
-    ttf_font_paths = {}
-    with open(os.path.join(static_dir, "google_fonts.css"), "w", encoding="utf-8") as f:
-        for key, (css_format_content, ttf_font_path) in css_content.items():
-            ttf_font_paths[key] = os.path.join(font_dir, ttf_font_path)
-            for content in css_format_content.values():
-                f.write("".join(re.split(r"(?:\s*\n\s*|/\*.*\*/)", content)))
-
-    app.add_css_file("google_fonts.css")
-    setattr(app, _TTF_FONT_PATHS_KEY, ttf_font_paths)
-
-
-def get_ttf_font_paths(app: sphinx.application.Sphinx) -> Dict[Tuple[str, str], str]:
-    return getattr(app, _TTF_FONT_PATHS_KEY)
-
-
-def _builder_inited(app: sphinx.application.Sphinx):
-    font_options = app.config["html_theme_options"]["font"]
-    if not font_options:
-        return
-    add_google_fonts(app, list(font_options.values()))
+def get_cache_dir(app: sphinx.application.Sphinx) -> str:
+    return getattr(app.config, _RESOURCE_CONFIG_KEY)
 
 
 def setup(app: sphinx.application.Sphinx):
@@ -235,8 +92,6 @@ def setup(app: sphinx.application.Sphinx):
         rebuild="env",
         types=(str,),
     )
-
-    app.connect("builder-inited", _builder_inited)
 
     return {
         "parallel_read_safe": True,

--- a/sphinx_immaterial/google_fonts.py
+++ b/sphinx_immaterial/google_fonts.py
@@ -1,0 +1,200 @@
+"""Downloads the user-requested Google Fonts and includes them in the output.
+
+This ensures the generated output does not depend on any external servers.
+
+Additionally, the fonts are used by the graphviz extension.
+"""
+
+import asyncio
+import concurrent.futures
+import hashlib
+import json
+import os
+import re
+from typing import Dict, List, Set, Tuple
+import urllib.parse
+
+import sphinx.application
+import sphinx.config
+import sphinx.util.logging
+
+from .external_resource_cache import get_url, get_cache_dir
+
+logger = sphinx.util.logging.getLogger(__name__)
+
+# From Google Fonts API Explorer
+_GOOGLE_FONTS_API_KEY = "AIzaSyAa8yy0GdcGPHdtD083HiGGx_S0vMPScDM"
+
+# https://stackoverflow.com/questions/25011533/google-font-api-uses-browser-detection-how-to-get-all-font-variations-for-font
+_FONT_FORMAT_USER_AGENT = {
+    "ttf": "Safari 3.1 Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_5_2; en-gb) AppleWebKit/526+ (KHTML, like Gecko) Version/3.1 iPhone",
+    "woff": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36",
+    # "Safari 6.0 Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25",
+    # 'woff2': 'Firefox 36.0 Mozilla/5.0 (Windows NT 6.3; rv:36.0) Gecko/20100101 Firefox/36.0',
+}
+
+
+_CSS_URL_PATTERN = re.compile(r"url\(([^\)]+)\)")
+
+_FILE_EXT_PATTERN = re.compile(r".*(\.[^\.]+)")
+
+
+def _extract_urls(css_content: bytes) -> Set[str]:
+    urls = set()
+    for m in _CSS_URL_PATTERN.finditer(css_content.decode("utf-8")):
+        urls.add(m.group(1))
+    return urls
+
+
+def _adjust_css_urls(css_content: bytes, renamed_fonts: Dict[str, str]) -> str:
+    css_text = css_content.decode("utf-8")
+    return _CSS_URL_PATTERN.sub(
+        lambda m: f"url(fonts/{renamed_fonts[m.group(1)]})", css_text
+    )
+
+
+_MAX_CONCURRENT_FETCHES = 128
+
+_TTF_FONT_PATHS_KEY = "sphinx_immaterial_ttf_font_paths"
+
+
+def add_google_fonts(app: sphinx.application.Sphinx, fonts: List[str]):
+
+    cache_dir = os.path.join(get_cache_dir(app), "google_fonts")
+    static_dir = os.path.join(app.outdir, "_static")
+    # _static path
+    font_dir = os.path.join(static_dir, "fonts")
+    os.makedirs(font_dir, exist_ok=True)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=32) as executor:
+
+        def to_thread(fn, *args, **kwargs) -> asyncio.Future:
+            return asyncio.wrap_future(executor.submit(fn, *args, **kwargs))
+
+        async def fetch_font(font: str, style: str):
+            css_url = f"https://fonts.googleapis.com/css?family={urllib.parse.quote(font)}:{style}"
+
+            css_content_future = asyncio.gather(
+                *[
+                    to_thread(
+                        get_url,
+                        cache_dir,
+                        css_url,
+                        headers={"user-agent": user_agent},
+                    )
+                    for user_agent in _FONT_FORMAT_USER_AGENT.values()
+                ]
+            )
+
+            css_content = dict(
+                zip(_FONT_FORMAT_USER_AGENT.keys(), await css_content_future)
+            )
+
+            font_files = set()
+            ttf_font_files = None
+
+            for font_format, css_data in css_content.items():
+                urls = _extract_urls(css_data)
+                font_files.update(urls)
+                if font_format == "ttf":
+                    ttf_font_files = urls
+
+            font_data_futures = asyncio.gather(
+                *[to_thread(get_url, cache_dir, font_url) for font_url in font_files]
+            )
+
+            all_font_data = dict(zip(font_files, await font_data_futures))
+
+            renamed_fonts = {}
+
+            for font_url, font_data in all_font_data.items():
+                h = hashlib.sha256(font_data).hexdigest()[:32]
+                m = _FILE_EXT_PATTERN.fullmatch(font_url)
+                if m is not None:
+                    file_ext = m.group(1)
+                else:
+                    file_ext = ""
+                new_name = h + file_ext
+                renamed_fonts[font_url] = new_name
+                with open(os.path.join(font_dir, new_name), "wb") as f:
+                    f.write(font_data)
+            adjusted_css_content = {
+                font_format: _adjust_css_urls(css_data, renamed_fonts)
+                for font_format, css_data in css_content.items()
+            }
+
+            ttf_font_path = None
+
+            if ttf_font_files is None or len(ttf_font_files) != 1:
+                logger.error(
+                    "Expected 1 TTF font for %s:%s but received: %r",
+                    font,
+                    style,
+                    css_content["ttf"],
+                )
+            else:
+                ttf_font_url = next(iter(ttf_font_files))
+                ttf_font_path = renamed_fonts[ttf_font_url]
+
+            return adjusted_css_content, ttf_font_path
+
+        async def do_fetch():
+            css_future_keys = []
+            css_futures = []
+            # Fetch list of fonts
+            font_metadata = json.loads(
+                get_url(
+                    cache_dir,
+                    f"https://content-webfonts.googleapis.com/v1/webfonts?key={_GOOGLE_FONTS_API_KEY}",
+                    headers={"x-referer": "https://explorer.apis.google.com"},
+                ).decode("utf-8")
+            )
+            font_families = {item["family"]: item for item in font_metadata["items"]}
+            for font in fonts:
+                metadata = font_families.get(font)
+                if metadata is None:
+                    logger.error(
+                        "Invalid font family %r, available font families are: %r",
+                        font,
+                        sorted(font_families),
+                    )
+                    continue
+                for variant in metadata["variants"]:
+                    css_future_keys.append((font, variant))
+                    css_futures.append(fetch_font(font, variant))
+            css_content = dict(zip(css_future_keys, await asyncio.gather(*css_futures)))
+            return css_content
+
+        css_content = asyncio.run(do_fetch())
+
+    # Write fonts css file
+    ttf_font_paths = {}
+    with open(os.path.join(static_dir, "google_fonts.css"), "w", encoding="utf-8") as f:
+        for key, (css_format_content, ttf_font_path) in css_content.items():
+            ttf_font_paths[key] = os.path.join(font_dir, ttf_font_path)
+            for content in css_format_content.values():
+                f.write("".join(re.split(r"(?:\s*\n\s*|/\*.*\*/)", content)))
+
+    app.add_css_file("google_fonts.css")
+    setattr(app, _TTF_FONT_PATHS_KEY, ttf_font_paths)
+
+
+def get_ttf_font_paths(app: sphinx.application.Sphinx) -> Dict[Tuple[str, str], str]:
+    return getattr(app, _TTF_FONT_PATHS_KEY)
+
+
+def _builder_inited(app: sphinx.application.Sphinx):
+    font_options = app.config["html_theme_options"]["font"]
+    if not font_options:
+        return
+    add_google_fonts(app, list(font_options.values()))
+
+
+def setup(app: sphinx.application.Sphinx):
+    app.setup_extension("sphinx_immaterial.external_resource_cache")
+    app.connect("builder-inited", _builder_inited)
+
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/sphinx_immaterial/google_fonts.py
+++ b/sphinx_immaterial/google_fonts.py
@@ -8,6 +8,7 @@ Additionally, the fonts are used by the graphviz extension.
 import asyncio
 import concurrent.futures
 import hashlib
+import io
 import json
 import os
 import re
@@ -18,6 +19,7 @@ import sphinx.application
 import sphinx.config
 import sphinx.util.logging
 
+from .css_and_javascript_bundles import add_global_css
 from .external_resource_cache import get_url, get_cache_dir
 
 logger = sphinx.util.logging.getLogger(__name__)
@@ -169,13 +171,12 @@ def add_google_fonts(app: sphinx.application.Sphinx, fonts: List[str]):
 
     # Write fonts css file
     ttf_font_paths = {}
-    with open(os.path.join(static_dir, "google_fonts.css"), "w", encoding="utf-8") as f:
-        for key, (css_format_content, ttf_font_path) in css_content.items():
-            ttf_font_paths[key] = os.path.join(font_dir, ttf_font_path)
-            for content in css_format_content.values():
-                f.write("".join(re.split(r"(?:\s*\n\s*|/\*.*\*/)", content)))
-
-    app.add_css_file("google_fonts.css")
+    css_data = io.StringIO()
+    for key, (css_format_content, ttf_font_path) in css_content.items():
+        ttf_font_paths[key] = os.path.join(font_dir, ttf_font_path)
+        for content in css_format_content.values():
+            css_data.write("".join(re.split(r"(?:\s*\n\s*|/\*.*\*/)", content)))
+    add_global_css(app, code=css_data.getvalue())
     setattr(app, _TTF_FONT_PATHS_KEY, ttf_font_paths)
 
 

--- a/sphinx_immaterial/graphviz.py
+++ b/sphinx_immaterial/graphviz.py
@@ -18,7 +18,7 @@ import sphinx.util.logging
 from sphinx.writers.html import HTMLTranslator
 from sphinx.writers.html5 import HTML5Translator
 
-from . import external_resource_cache
+from . import google_fonts
 from . import sphinx_utils
 
 logger = sphinx.util.logging.getLogger(__name__)
@@ -235,10 +235,10 @@ def render_dot_html(
 ) -> Tuple[str, str]:
 
     theme_options = self.builder.config["html_theme_options"]
-    ttf_font_paths = external_resource_cache.get_ttf_font_paths(self.builder.app)
+    ttf_font_paths = google_fonts.get_ttf_font_paths(self.builder.app)
     font = theme_options["font"]["text"]
 
-    ttf_font = ttf_font_paths[(font, "400")]
+    ttf_font = ttf_font_paths[(font, "regular")]
 
     code = _replace_resolved_xrefs(node, code)
 

--- a/sphinx_immaterial/inline_icons.py
+++ b/sphinx_immaterial/inline_icons.py
@@ -2,12 +2,25 @@
 primarily, the icons bundled with this theme are supported (plus any svg files in the
 user project's static directories)."""
 from pathlib import Path
-from typing import Tuple, List
+from typing import Tuple, List, Dict
+
 from docutils import nodes
 from sphinx.application import Sphinx
 from sphinx.builders import Builder
+import sphinx.environment
 from sphinx.writers.html5 import HTML5Translator
 from sphinx.util.docutils import SphinxRole
+
+
+CUSTOM_ICON_KEY = "_sphinx_immaterial_custom_icons"
+
+
+def get_custom_icons(env: sphinx.environment.BuildEnvironment) -> Dict[str, str]:
+    custom_icons = getattr(env, CUSTOM_ICON_KEY, None)
+    if custom_icons is None:
+        custom_icons = {}
+        setattr(env, CUSTOM_ICON_KEY, custom_icons)
+    return custom_icons
 
 
 def load_svg_into_builder_env(builder: Builder, icon_name: str) -> str:
@@ -15,8 +28,8 @@ def load_svg_into_builder_env(builder: Builder, icon_name: str) -> str:
 
     Returns: The name of CSS class associated with the SVG data."""
     css_icon_name = icon_name.replace("/", "_").replace("\\", "_")
-    custom_icons = getattr(builder.env, "sphinx_immaterial_custom_icons", {})
     icon_name += ".svg"
+    custom_icons = get_custom_icons(builder.env)
     if css_icon_name not in custom_icons:
         static_paths: List[str] = getattr(builder.config, "sphinx_immaterial_icon_path")
         for path in static_paths:
@@ -31,7 +44,6 @@ def load_svg_into_builder_env(builder: Builder, icon_name: str) -> str:
                     " not bundled with the theme"
                 )
         custom_icons[css_icon_name] = svg.read_text(encoding="utf-8")
-        setattr(builder.env, "sphinx_immaterial_custom_icons", custom_icons)
     return css_icon_name
 
 
@@ -65,8 +77,18 @@ class IconsRole(SphinxRole):
         return [div], []
 
 
+def _merge_info(
+    app: sphinx.application.Sphinx,
+    env: sphinx.environment.BuildEnvironment,
+    docnames: List[str],
+    other: sphinx.environment.BuildEnvironment,
+) -> None:
+    get_custom_icons(env).update(get_custom_icons(other))
+
+
 def setup(app: Sphinx):
 
+    app.connect("env-merge-info", _merge_info)
     app.add_role("si-icon", IconsRole())
     app.add_node(si_icon, html=(visit_si_icon, None))
 

--- a/src/base.html
+++ b/src/base.html
@@ -408,9 +408,8 @@
     {% endblock %}
 
     <!-- Theme-related JavaScript -->
-    {% block scripts %}
-      <script src="{{ pathto('_static/javascripts/bundle.js', resource=True) }}"></script>
-
+      {% block scripts %}
+      <!-- sphinx-immaterial: bundled JavaScript is added from `script_files -->
       <!-- Custom JavaScript -->
       {%- for js in script_files %}
         {{ js_tag(js) }}

--- a/tools/build/index.ts
+++ b/tools/build/index.ts
@@ -157,7 +157,7 @@ const javascripts$ = resolve("**/bundle.ts", { cwd: "src/assets" })
       of(ext(file, ".js")),
       transformScript({
         from: `src/assets/${file}`,
-        to: ext(`${base}/static/${file}`, ".js")
+        to: ext(`${base}/bundles/${file}`, ".js")
       }))
     )
   )
@@ -207,7 +207,7 @@ const manifest$ = merge(
     scan((prev, mapping) => {
       for (const [sourcePath, {file, licenseMap}] of mapping) {
         bundleLicenses.set(file, licenseMap)
-        prev.set(sourcePath, file.replace(`${base}/static/`, ""))
+        prev.set(sourcePath, file.replace(`${base}/bundles/`, ""))
       }
       return prev
     }, new Map<string, string>()),
@@ -220,7 +220,7 @@ const manifest$ = merge(
 /* Transform templates */
 const templates$ = manifest$
   .pipe(
-    switchMap(manifest => copyAll("**/*.html", {
+    switchMap(_manifest => copyAll("**/*.html", {
       from: "src",
       to: base,
       watch: process.argv.includes("--watch"),
@@ -230,17 +230,6 @@ const templates$ = manifest$
           "{#-\n" +
           "  This file was automatically generated - do not edit\n" +
           "-#}\n"
-
-        /* If necessary, apply manifest */
-        if (process.argv.includes("--optimize"))
-          for (let [key, value] of manifest) {
-            key = key.replace("\\", "/")
-            value = value.replace("\\", "/")
-            data = data.replace(
-              new RegExp(`('|")_static/${key}\\1`, "g"),
-              `$1_static/${value}$1`
-            )
-          }
 
         /* Normalize line feeds and minify HTML */
         const html = data.replace(/\r\n/gm, "\n")


### PR DESCRIPTION
- Use Google Fonts metadata to fetch all available variants
    
  Previously, this theme retrieved a hardcoded list of font variants, as
  specified by the mkdocs-material theme.  However, it was reported in #193
  that some fonts do not have all of these variants, leading to an error
  when trying to use such a font.

  With this change, the precise list of variants for each font is used
  by fetching the complete list of fonts and variants from the Google
  Fonts API.

  This commit also factors out the Google Fonts retrieval logic from
  `external_resource_cache.py` into a separate `google_fonts.py` module.

  Fixes #193.

- Refactor CSS and JavaScript bundle output and support source maps
    
  This refactors the existing CSS bundling code in
  `custom_admonitions.py` in the following ways:

  - JavaScript bundling is supported in addition to CSS.

  - The `add_global_{css,javascript}` functions are added to allow other
    modules to register additional sources.

  - Source maps are supported, and are generated when
    `sphinx_immaterial_bundle_source_maps = True`.

  - The new `add_global_css` function is used to add the Google Fonts
    CSS to the CSS bundle, rather than as a separate .css file.

- Properly include required custom icons in parallel builds

- Exclude sphinx_highlight.js file from basic theme
    
  The file is not needed by this theme.

- Fix typos in Python domain customization documentation