### PR TITLE
Fix source info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -408,7 +408,6 @@ disable = [
     "line-too-long",
     "fixme",
     "cyclic-import",
-    "unused-import",
     "too-many-arguments"
 ]
 
@@ -416,7 +415,7 @@ disable = [
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where it
 # should appear only once). See also the "--disable" option for examples.
-enable = ["c-extension-no-member"]
+enable = ["c-extension-no-member", "unused-import", "init-import"]
 
 [tool.pylint.miscellaneous]
 # List of note tags to take in consideration, separated by a comma.

--- a/sphinx_immaterial/__init__.py
+++ b/sphinx_immaterial/__init__.py
@@ -18,7 +18,7 @@ from . import html_translator_mixin
 from .apidoc import apidoc_formatting
 from .apidoc import fix_sphinx_issue_11147  # pylint: disable=unused-import
 from . import nav_adapt
-from . import sections
+from . import sections  # pylint: disable=unused-import
 
 logger = sphinx.util.logging.getLogger(__name__)
 

--- a/sphinx_immaterial/__init__.py
+++ b/sphinx_immaterial/__init__.py
@@ -16,6 +16,7 @@ import sphinx.writers.html5
 
 from . import html_translator_mixin
 from .apidoc import apidoc_formatting
+from .apidoc import fix_sphinx_issue_11147  # pylint: disable=unused-import
 from . import nav_adapt
 from . import sections
 

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -31,15 +31,12 @@ This program performs a number of transformations on the declarations:
 """
 
 import argparse
-import collections
 import dataclasses
-import enum
 import functools
 import json
 import os
 import pathlib
 import re
-import sys
 import time
 import typing
 from typing import (
@@ -72,7 +69,7 @@ import pydantic.dataclasses
 import sphinx.domains.cpp
 import sphinx.util.logging
 
-from . import ast_fixes  # type: ignore[unused-import]
+from . import ast_fixes  # pylint: disable=unused-import
 
 logger = sphinx.util.logging.getLogger(__name__)
 

--- a/sphinx_immaterial/apidoc/cpp/apigen.py
+++ b/sphinx_immaterial/apidoc/cpp/apigen.py
@@ -29,7 +29,6 @@ import sphinx.util.logging
 from .. import apigen_utils
 from ... import sphinx_utils
 from . import api_parser
-from ... import default_literal_role
 from .signodes import desc_cpp_explicit
 
 logger = sphinx.util.logging.getLogger(__name__)

--- a/sphinx_immaterial/apidoc/cpp/ast_fixes.py
+++ b/sphinx_immaterial/apidoc/cpp/ast_fixes.py
@@ -2,9 +2,13 @@
 
 import sphinx
 
-from . import fix_cpp_domain_symbol_resolution_through_type_aliases  # type: ignore[unused-import]
+from . import (  # pylint: disable=unused-import
+    fix_cpp_domain_symbol_resolution_through_type_aliases,
+)
 
 if sphinx.version_info < (5, 2):
-    from . import fix_cpp_domain_requires_clause  # type: ignore[unused-import]
-    from . import fix_cpp_is_pack  # type: ignore[unused-import]
-    from . import fix_cpp_symbol_to_normalize_template_args  # type: ignore[unused-import]
+    from . import fix_cpp_domain_requires_clause  # pylint: disable=unused-import
+    from . import fix_cpp_is_pack  # pylint: disable=unused-import
+    from . import (  # pylint: disable=unused-import
+        fix_cpp_symbol_to_normalize_template_args,
+    )

--- a/sphinx_immaterial/apidoc/cpp/cpp_resolve_c_xrefs.py
+++ b/sphinx_immaterial/apidoc/cpp/cpp_resolve_c_xrefs.py
@@ -25,8 +25,8 @@ from sphinx.domains.cpp import CPPExprRole
 # We monkey patch `resolve_xref` multiple times.  We must call
 # `_monkey_patch_cpp_resolve_c_xrefs` last, to ensure that the other logic only
 # runs once.
-from . import last_resolved_symbol  # type: ignore[unused-import]
-from . import synopses  # type: ignore[unused-import]
+from . import last_resolved_symbol  # pylint: disable=unused-import
+from . import synopses  # pylint: disable=unused-import
 
 POSSIBLE_MACRO_TARGET_PATTERN = re.compile("^[A-Z]+[A-Z_0-9]*(?:::[a-zA-Z0-9_]+)?$")
 """Pattern for targets that may possibly refer to a macro or macro parameter.

--- a/sphinx_immaterial/apidoc/cpp/default.py
+++ b/sphinx_immaterial/apidoc/cpp/default.py
@@ -1,15 +1,15 @@
 import sphinx.application
 
-from . import ast_fixes  # type: ignore[unused-import]
-from . import cpp_resolve_c_xrefs  # type: ignore[unused-import]
-from . import include_directives_in_signatures  # type: ignore[unused-import]
-from . import last_resolved_symbol  # type: ignore[unused-import]
-from . import macro_parameters  # type: ignore[unused-import]
-from . import parameter_objects  # type: ignore[unused-import]
-from . import signodes  # type: ignore[unused-import]
-from . import strip_namespaces_from_signatures  # type: ignore[unused-import]
-from . import symbol_ids  # type: ignore[unused-import]
-from . import synopses  # type: ignore[unused-import]
+from . import ast_fixes  # pylint: disable=unused-import
+from . import cpp_resolve_c_xrefs  # pylint: disable=unused-import
+from . import include_directives_in_signatures  # pylint: disable=unused-import
+from . import last_resolved_symbol  # pylint: disable=unused-import
+from . import macro_parameters  # pylint: disable=unused-import
+from . import parameter_objects  # pylint: disable=unused-import
+from . import signodes  # pylint: disable=unused-import
+from . import strip_namespaces_from_signatures  # pylint: disable=unused-import
+from . import symbol_ids  # pylint: disable=unused-import
+from . import synopses  # pylint: disable=unused-import
 
 
 def setup(app: sphinx.application.Sphinx):

--- a/sphinx_immaterial/apidoc/fix_sphinx_issue_11147.py
+++ b/sphinx_immaterial/apidoc/fix_sphinx_issue_11147.py
@@ -1,0 +1,29 @@
+"""Monkey patches a fix for https://github.com/sphinx-doc/sphinx/pull/11147."""
+
+import inspect
+
+import sphinx.util.nodes
+import sphinx.util.docutils
+
+
+def _monkey_patch_nested_parse_with_titles():
+    orig_nested_parse_with_titles = sphinx.util.nodes.nested_parse_with_titles
+
+    if list(inspect.signature(orig_nested_parse_with_titles).parameters.keys()) != [
+        "state",
+        "content",
+        "node",
+    ]:
+        # Assume https://github.com/sphinx-doc/sphinx/pull/11147 has been merged.
+        return
+
+    # Note that this is different from the fix in
+    # https://github.com/sphinx-doc/sphinx/pull/11147, since it is not practical
+    # to monkey patch all callers to pass in the `content_offset`.  Instead, we
+    # use `switch_source_input`, which makes it unnecessary to pass in
+    # `content_offset`.
+    def nested_parse_with_titles(state, content, node):
+        with sphinx.util.docutils.switch_source_input(state, content):
+            return orig_nested_parse_with_titles(state, content, node)
+
+    sphinx.util.nodes.nested_parse_with_titles = nested_parse_with_titles

--- a/sphinx_immaterial/apidoc/fix_sphinx_issue_11147.py
+++ b/sphinx_immaterial/apidoc/fix_sphinx_issue_11147.py
@@ -2,6 +2,7 @@
 
 import inspect
 
+import sphinx.directives
 import sphinx.util.nodes
 import sphinx.util.docutils
 
@@ -27,3 +28,7 @@ def _monkey_patch_nested_parse_with_titles():
             return orig_nested_parse_with_titles(state, content, node)
 
     sphinx.util.nodes.nested_parse_with_titles = nested_parse_with_titles
+    sphinx.directives.nested_parse_with_titles = nested_parse_with_titles
+
+
+_monkey_patch_nested_parse_with_titles()

--- a/sphinx_immaterial/apidoc/json/domain.py
+++ b/sphinx_immaterial/apidoc/json/domain.py
@@ -45,7 +45,6 @@ import yaml  # pylint: disable=import-error
 from .. import object_description_options
 from . import json_pprint
 from ... import sphinx_utils
-from ... import default_literal_role
 from .. import apigen_utils
 
 logger = sphinx.util.logging.getLogger(__name__)

--- a/sphinx_immaterial/apidoc/python/apigen.py
+++ b/sphinx_immaterial/apidoc/python/apigen.py
@@ -16,11 +16,9 @@ display the signatures nicely.
 
 import copy
 import dataclasses
-import hashlib
 import importlib
 import inspect
 import json
-import os
 import re
 from typing import (
     List,
@@ -56,7 +54,6 @@ import sphinx.util.typing
 from .. import object_description_options
 from ... import sphinx_utils
 from .. import apigen_utils
-from ... import default_literal_role
 
 if sphinx.version_info >= (6, 1):
     stringify_annotation = sphinx.util.typing.stringify_annotation

--- a/sphinx_immaterial/apidoc/python/default.py
+++ b/sphinx_immaterial/apidoc/python/default.py
@@ -1,3 +1,4 @@
+import sphinx
 import sphinx.application
 
 from . import annotation_style
@@ -9,10 +10,12 @@ from . import subscript_methods
 from . import attribute_style
 from . import napoleon_admonition_classes
 from . import strip_property_prefix
-from . import section_titles
 from . import autodoc_property_type
 from . import type_annotation_transforms
 from . import strip_self_and_return_type_annotations
+
+if sphinx.version_info < (5, 3):
+    from . import section_titles
 
 
 def setup(app: sphinx.application.Sphinx):

--- a/sphinx_immaterial/apidoc/python/default.py
+++ b/sphinx_immaterial/apidoc/python/default.py
@@ -1,21 +1,21 @@
 import sphinx
 import sphinx.application
 
-from . import annotation_style
-from . import object_ids
-from . import synopses
+from . import annotation_style  # pylint: disable=unused-import
+from . import object_ids  # pylint: disable=unused-import
+from . import synopses  # pylint: disable=unused-import
 from . import parameter_objects
-from . import style_default_values_as_code
-from . import subscript_methods
-from . import attribute_style
-from . import napoleon_admonition_classes
+from . import style_default_values_as_code  # pylint: disable=unused-import
+from . import subscript_methods  # pylint: disable=unused-import
+from . import attribute_style  # pylint: disable=unused-import
+from . import napoleon_admonition_classes  # pylint: disable=unused-import
 from . import strip_property_prefix
-from . import autodoc_property_type
+from . import autodoc_property_type  # pylint: disable=unused-import
 from . import type_annotation_transforms
 from . import strip_self_and_return_type_annotations
 
 if sphinx.version_info < (5, 3):
-    from . import section_titles
+    from . import section_titles  # pylint: disable=unused-import
 
 
 def setup(app: sphinx.application.Sphinx):

--- a/sphinx_immaterial/apidoc/python/domain_fixes.py
+++ b/sphinx_immaterial/apidoc/python/domain_fixes.py
@@ -1,22 +1,5 @@
 """Fixes for the Python domain."""
 
-import json
-import re
-from typing import (
-    cast,
-    Sequence,
-    Tuple,
-    List,
-    Dict,
-    Type,
-    Optional,
-    Any,
-    Iterator,
-    Union,
-)
-
-import docutils.nodes
-import docutils.parsers.rst.states
 import sphinx
 import sphinx.addnodes
 import sphinx.application
@@ -29,8 +12,7 @@ import sphinx.ext.napoleon
 import sphinx.util.logging
 import sphinx.util.nodes
 
-from ... import sphinx_utils
-from . import autodoc_property_type
+from . import autodoc_property_type  # pylint: disable=unused-import
 
 PythonDomain = sphinx.domains.python.PythonDomain
 PyTypedField = sphinx.domains.python.PyTypedField

--- a/sphinx_immaterial/apidoc/python/section_titles.py
+++ b/sphinx_immaterial/apidoc/python/section_titles.py
@@ -1,8 +1,13 @@
 import docutils.nodes
 import docutils.statemachine
 
+import sphinx
 from sphinx.domains.python import PyObject
 import sphinx.util.nodes
+
+
+# Not needed in Sphinx 5.3
+assert sphinx.version_info < (5, 3)
 
 
 def _monkey_patch_python_domain_to_support_titles():

--- a/sphinx_immaterial/custom_admonitions.py
+++ b/sphinx_immaterial/custom_admonitions.py
@@ -1,11 +1,9 @@
 """This module inherits from the generic ``admonition`` directive and makes the
 title optional."""
 from abc import ABC
-import io
-import hashlib
-from pathlib import Path, PurePath
+from pathlib import PurePath
 import re
-from typing import List, Dict, Any, Tuple, Optional, Type, Union, cast
+from typing import List, Dict, Any, Tuple, Optional, Type, cast
 from docutils import nodes
 from docutils.parsers.rst import directives, Directive
 import jinja2

--- a/sphinx_immaterial/external_resource_cache.py
+++ b/sphinx_immaterial/external_resource_cache.py
@@ -1,12 +1,8 @@
-import asyncio
-import concurrent.futures
 import hashlib
 import json
 import os
-import re
 import tempfile
-from typing import Dict, Optional, List, Set, Tuple
-import urllib.parse
+from typing import Dict, Optional
 
 import appdirs
 import requests

--- a/sphinx_immaterial/sections.py
+++ b/sphinx_immaterial/sections.py
@@ -14,8 +14,6 @@ That is accomplished by overriding `visit_section` and
 modifying `visit_title` to insert the `id`.
 """
 
-from typing import Callable
-
 import docutils.nodes
 
 from . import html_translator_mixin


### PR DESCRIPTION
- Remove unused imports and enable unused-imports lint

-  Add monkey patch to fix source file/line number info for object descriptions

   - This addresses the issue described at https://github.com/sphinx-doc/sphinx/pull/11147.

- Disable apidoc/python/section_titles monkey patch for Sphinx >= 5.3
    
  - This is unnecessary due to
    https://github.com/sphinx-doc/sphinx/issues/10887, which adds support
    for section titles in all object description content.
