### PR TITLE
ci: schedule twice a month

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: Build
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1,16 * *'
 
 jobs:
   build:


### PR DESCRIPTION
Since sphinx-immaterial has a bunch of dependencies, the package can break despite not making any modification to the sources. Actually, software nowadays tends to break unless it is continuously maintained.

Since this repo was not modified in a month, CI was not triggered. The readme shows a green shield/badge. However, the fact is that CI is currently broken.

This PR adds an `schedule` trigger to the `build` workflow in order to ensure that breaking changes in the dependencies are caught soon, regardless of the activity in this repo.