### PR TITLE
ci: do not fail fast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - 'ubuntu-latest'


### PR DESCRIPTION
Currently, if any job of the matrix fails, all others are cancelled automatically. However, some versions of Python might work while other fail. Or some versions might works on some platforms but fail on others.

This PR unsets `fail-fast`, in order to allow all jobs to finish regardless of one or some of them failing.