### PR TITLE
Fixed double numfig statements for Figues and no listing number for code blocks

### DIFF
--- a/sphinx_immaterial/apidoc/apidoc_formatting.py
+++ b/sphinx_immaterial/apidoc/apidoc_formatting.py
@@ -61,11 +61,15 @@ def visit_caption(
         # This is needed to trigger mkdocs-material CSS rule `.highlight .filename`
         self.body.append('<div class="code-block-caption highlight">')
         # append a CSS class to trigger mkdocs-material theme's caption CSS style
-        attributes["class"] += " filename"
+        # create a span wrapping caption's content and (optionally) number
+        self.body.append('<span class="filename">')
+        # append a listing number
+        self.add_fignumber(node.parent)
+        self.body.append(self.starttag(node, "span", **attributes))
+        self.body.append("</span>")
     else:
         super_func(self, node)
-    self.add_fignumber(node.parent)
-    self.body.append(self.starttag(node, "span", **attributes))
+        self.body.append(self.starttag(node, "span", **attributes))
 
 
 @html_translator_mixin.override


### PR DESCRIPTION
The explicit `add_fignumber` adds rendering of another figure number, resulting in double Fig entries in rendered doc. In addition, for code listings the Listing appears as a raw text above the code block:

![double-fig](https://user-images.githubusercontent.com/46489721/222167879-7d02aa33-54ba-46d3-8e0f-39de7660e348.png)

This PR removes the excessive number for tables and figures (code blocks require it). In addition, the Listing number, as well as listing caption are wrapped in `filename` class so they appear as listing content above the code block. The result is following:

![double-fig-removed](https://user-images.githubusercontent.com/46489721/222168420-714ea23e-366b-4dc9-aa2b-6ad85f973399.png)