### PR TITLE
Extends docs with hint when migrating

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Installation
 
 From the PyPI
 ^^^^^^^^^^^^^
+
 .. code-block:: bash
 
    pip install sphinx-immaterial
@@ -79,6 +80,11 @@ or ``theme.conf`` for more details.
     .. literalinclude:: ./conf.py
         :start-after: # -- HTML theme specific settings
         :end-before: # end html_theme_options
+
+.. important:: Migrating from another theme
+   :collapsible:
+
+   Be advised to clean prior builds before the first build with a new theme.
 
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,7 +82,7 @@ or ``theme.conf`` for more details.
         :end-before: # end html_theme_options
 
 .. important:: 
-    :title: Migrating from another theme
+   :title: Migrating from another theme
    :collapsible:
 
    Be advised to clean prior builds before the first build with a new theme.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,7 +81,8 @@ or ``theme.conf`` for more details.
         :start-after: # -- HTML theme specific settings
         :end-before: # end html_theme_options
 
-.. important:: Migrating from another theme
+.. important:: 
+    :title: Migrating from another theme
    :collapsible:
 
    Be advised to clean prior builds before the first build with a new theme.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,7 +81,7 @@ or ``theme.conf`` for more details.
         :start-after: # -- HTML theme specific settings
         :end-before: # end html_theme_options
 
-.. important:: 
+.. important::
    :title: Migrating from another theme
    :collapsible:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,22 @@ significantly diverged from the upstream `mkdocs-material
 Getting Started
 ---------------
 
+Installation
+~~~~~~~~~~~~
+
+From the PyPI
+^^^^^^^^^^^^^
+.. code-block:: bash
+
+   pip install sphinx-immaterial
+
+From git source
+^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   pip install git+https://github.com/jbms/sphinx-immaterial.git
+
 .. admonition:: Prerequisites
 
     Building the theme from source requires node.js v14 or newer installed.
@@ -41,11 +57,9 @@ Getting Started
     Installing from a distributed wheel (such as from pypi.org) does not require
     node.js installed.
 
-Install from git source
 
-.. code-block:: bash
-
-   pip install git+https://github.com/jbms/sphinx-immaterial.git
+Sphinx configuration
+~~~~~~~~~~~~~~~~~~~~
 
 Update your ``conf.py`` with the required changes:
 


### PR DESCRIPTION
as mentioned in #238, here's a little docs extension for people who are switching from another theme. i made it collapsed by default as it could potentially grow. for now i'm setting my migration more or less aside, so that's all as first impression.

on that occasion, i think the docs could really benefit from a section for hackers. i noticed inconsistencies how admonitions are parsed and it took me a while to get a grip how i should set up a test for that. admittedly i'm not in best condition atm and then dealing with `docutils` is just too much of a pita.