### PR TITLE
support version directives

### DIFF
--- a/docs/admonitions.rst
+++ b/docs/admonitions.rst
@@ -53,6 +53,34 @@ usage in other sphinx-based themes.
    .. error::
       You have made a grave :dutree:`error`.
 
+Version directives
+******************
+
+The `versionadded`, `versionchanged`, and `deprecated` directives defined by Sphinx are also
+overridden by the sphinx-immaterial theme to render as an admonition.
+
+.. confval:: sphinx_immaterial_override_version_directives
+
+   This theme can be configured to disallow these overrides if the new features cause a conflict
+   with other Sphinx extensions.
+
+   .. code-block:: python
+      :caption: Disallow overriding version directives in conf.py
+
+      sphinx_immaterial_override_version_directives = False
+
+.. rst-example::
+
+    .. versionadded:: 1.0
+        Description in title.
+
+        Some additional context.
+    .. versionchanged:: 2.0
+        Description in title.
+    .. deprecated:: 3.0
+
+        No extra description in title.
+
 .. _inherited_admonitions:
 
 Admonitions from mkdocs-material

--- a/src/assets/stylesheets/main/_sphinx.scss
+++ b/src/assets/stylesheets/main/_sphinx.scss
@@ -83,4 +83,8 @@
   .viewcode-block .viewcode-back {
     float: right;
   }
+
+  .versionmodified {
+    font-style: italic;
+  }
 }


### PR DESCRIPTION
resolves #243

- Overrides version directives `versionadded`, `versionchanged`, and `deprecated` with custom admonition directives.
- Adds new conf.py option `sphinx_immaterial_override_version_directives` to disable this new behavior.
- Adds CSS to italicize the version directive "label" as is done in the Sphinx basic theme CSS.
- Updates the admonitions.rst doc
- Admonition content is optional for newly overridden version directives. Content is still required for existing admonition overrides (as is the default behavior)
- Overridden version directives require 1 argument and still support 1 optional argument.