### PR TITLE
Styling version directives

### DIFF
--- a/docs/admonitions.rst
+++ b/docs/admonitions.rst
@@ -53,6 +53,40 @@ usage in other sphinx-based themes.
    .. error::
       You have made a grave :dutree:`error`.
 
+Version Directives
+******************
+
+The `versionadded`, `versionchanged`, and `deprecated` directives defined by Sphinx are also
+rendered by the sphinx-immaterial theme as admonitions.
+
+These admonition styles can be customized using the `Custom Admonitions`_ feature provided the
+:py:attr:`~sphinx_immaterial.custom_admonitions.CustomAdmonitionConfig.name` matches the directive
+name, but only the
+:py:attr:`~sphinx_immaterial.custom_admonitions.CustomAdmonitionConfig.icon` and
+:py:attr:`~sphinx_immaterial.custom_admonitions.CustomAdmonitionConfig.color` options will apply;
+all other options are ignored.
+
+.. code-block:: py
+   :caption: Adjusting the `versionchanged` style
+
+   sphinx_immaterial_custom_admonitions = [
+        {
+            "name": "versionchanged",
+            "color": (27, 138, 236),
+            "icon": "material/alert-rhombus",
+        }
+    ]
+
+.. rst-example::
+
+    .. versionadded:: 1.0
+        Description in title.
+
+        Some additional context.
+    .. versionchanged:: 2.0
+        Description in title.
+    .. deprecated:: 3.0
+
 .. _inherited_admonitions:
 
 Admonitions from mkdocs-material

--- a/docs/admonitions.rst
+++ b/docs/admonitions.rst
@@ -67,9 +67,9 @@ name, but only the
 all other options are ignored.
 
 .. code-block:: py
-   :caption: Adjusting the `versionchanged` style
+    :caption: Adjusting the `versionchanged` style
 
-   sphinx_immaterial_custom_admonitions = [
+    sphinx_immaterial_custom_admonitions = [
         {
             "name": "versionchanged",
             "color": (27, 138, 236),

--- a/sphinx_immaterial/custom_admonitions.py
+++ b/sphinx_immaterial/custom_admonitions.py
@@ -285,14 +285,11 @@ def on_builder_inited(app: Sphinx):
     for admonition in custom_admonitions:
         custom_admonition_names.append(admonition.name)
         if admonition.name in VERSION_DIR_STYLE:  # if specific to version directives
-            if admonition.icon is None:  # for default icon
-                admonition.icon = load_svg_into_builder_env(
-                    app.builder, cast(str, VERSION_DIR_STYLE[admonition.name]["icon"])
-                )
-            else:  # for user-defined icon
-                admonition.icon = load_svg_into_builder_env(
-                    app.builder, admonition.icon
-                )
+            admonition.icon = load_svg_into_builder_env(
+                app.builder,
+                admonition.icon
+                or cast(str, VERSION_DIR_STYLE[admonition.name]["icon"]),
+            )
             if admonition.color is None:
                 admonition.color = cast(
                     Tuple[int, int, int], VERSION_DIR_STYLE[admonition.name]["color"]

--- a/src/assets/stylesheets/main/_sphinx.scss
+++ b/src/assets/stylesheets/main/_sphinx.scss
@@ -83,4 +83,8 @@
   .viewcode-block .viewcode-back {
     float: right;
   }
+
+  .versionmodified {
+    font-style: italic;
+  }
 }


### PR DESCRIPTION
resolves #243

This does not override the original sphinx directives `versionadded`, `versionchanged`, and `deprecated`. Rather, the CSS styles have been adjusted to render these directives as admonitions. The default styles can be customized using the custom admonitions feature, but only `color` and `icon` will apply (as long as the `name` matches the directive name).

Also adds the italicized style inherent in Sphinx' basic theme CSS.

Updated admonitions.rst accordingly.