### PR TITLE
remove unnecessary permalink to `depart_term()`

### DIFF
--- a/docs/additional_samples.rst
+++ b/docs/additional_samples.rst
@@ -190,17 +190,19 @@ Alignment
 Glossaries
 ==========
 
-.. glossary::
+.. rst-example::
 
-   environment
-      A structure where information about all documents under the root is
-      saved, and used for cross-referencing.  The environment is pickled
-      after the parsing stage, so that successive runs only need to read
-      and parse new and changed documents.
+   .. glossary::
 
-   source directory
-      The directory which, including its subdirectories, contains all
-      source files for one Sphinx project.
+      environment
+         A structure where information about all documents under the root is
+         saved, and used for cross-referencing.  The environment is pickled
+         after the parsing stage, so that successive runs only need to read
+         and parse new and changed documents.
+
+      source directory
+         The directory which, including its subdirectories, contains all
+         source files for one Sphinx project.
 
 Math
 ====

--- a/sphinx_immaterial/apidoc/object_toc.py
+++ b/sphinx_immaterial/apidoc/object_toc.py
@@ -294,7 +294,11 @@ def depart_term(
     node: docutils.nodes.term,
     super_func: html_translator_mixin.BaseVisitCallback[docutils.nodes.term],
 ) -> None:
-    self.add_permalink_ref(node, _("Permalink to this definition"))
+    next_node: docutils.nodes.Element = node.next_node(descend=False, siblings=True)
+    if not isinstance(next_node, docutils.nodes.classifier) and not isinstance(
+        node.parent.parent.parent, sphinx.addnodes.glossary
+    ):
+        self.add_permalink_ref(node, _("Permalink to this definition"))
     super_func(self, node)
 
 

--- a/sphinx_immaterial/apidoc/object_toc.py
+++ b/sphinx_immaterial/apidoc/object_toc.py
@@ -295,8 +295,11 @@ def depart_term(
     super_func: html_translator_mixin.BaseVisitCallback[docutils.nodes.term],
 ) -> None:
     next_node: docutils.nodes.Element = node.next_node(descend=False, siblings=True)
-    if not isinstance(next_node, docutils.nodes.classifier) and not isinstance(
-        node.parent.parent.parent, sphinx.addnodes.glossary
+    if (
+        not isinstance(next_node, docutils.nodes.classifier)
+        and node.parent is not None
+        and node.parent.parent is not None
+        and not isinstance(node.parent.parent.parent, sphinx.addnodes.glossary)
     ):
         self.add_permalink_ref(node, _("Permalink to this definition"))
     super_func(self, node)

--- a/sphinx_immaterial/apidoc/object_toc.py
+++ b/sphinx_immaterial/apidoc/object_toc.py
@@ -295,11 +295,10 @@ def depart_term(
     super_func: html_translator_mixin.BaseVisitCallback[docutils.nodes.term],
 ) -> None:
     next_node: docutils.nodes.Element = node.next_node(descend=False, siblings=True)
-    if (
-        not isinstance(next_node, docutils.nodes.classifier)
-        and node.parent is not None
+    if not isinstance(next_node, docutils.nodes.classifier) and not (
+        node.parent is not None
         and node.parent.parent is not None
-        and not isinstance(node.parent.parent.parent, sphinx.addnodes.glossary)
+        and isinstance(node.parent.parent.parent, sphinx.addnodes.glossary)
     ):
         self.add_permalink_ref(node, _("Permalink to this definition"))
     super_func(self, node)


### PR DESCRIPTION
resolves #248

The problem doesn't seem instigated by any changes to docutils or sphinx. So, it may have been something that was originally overlooked in #157.

Use `rst-example` for the `glossary` directive in additional_samples.rst