### PR TITLE
support admonition options in version directives (follow-up to #246)

### DIFF
--- a/docs/admonitions.rst
+++ b/docs/admonitions.rst
@@ -57,9 +57,28 @@ Version Directives
 ******************
 
 The `versionadded`, `versionchanged`, and `deprecated` directives defined by Sphinx are also
-rendered by the sphinx-immaterial theme as admonitions.
+overridden by the sphinx-immaterial theme to render as :rst:dir:`admonition`\ s with added
+functionality (like optionally making them :rst:`:collapsible:`).
 
-These admonition styles can be customized using the `Custom Admonitions`_ feature provided the
+Beware, these directive overrides do not support the :rst:`:title:` and
+:rst:`:no-title:` options because
+
+1. They require 1 argument (and optionally 1 additional argument) that gets used in the title.
+2. The default title cannot be changed.
+
+.. confval:: sphinx_immaterial_override_version_directives
+
+   This theme can be configured to disallow these overrides if the new features cause a conflict
+   with other Sphinx extensions.
+
+   .. code-block:: python
+      :caption: Disallow overriding builtin version directives in conf.py
+
+      sphinx_immaterial_override_version_directives = False
+
+These admonition styles can be customized (despite the
+:confval:`sphinx_immaterial_override_version_directives` value) using the `Custom Admonitions`_
+feature provided the
 :py:attr:`~sphinx_immaterial.custom_admonitions.CustomAdmonitionConfig.name` matches the directive
 name, but only the
 :py:attr:`~sphinx_immaterial.custom_admonitions.CustomAdmonitionConfig.icon`,
@@ -78,15 +97,10 @@ all other options are ignored.
         }
     ]
 
-Beware, these directives do not support the :rst:`:title:` and :rst:`:no-title:` options because
-
-1. They require 1 argument (and optionally 1 additional argument) that gets used in the title.
-2. The default title cannot be changed.
-
 .. rst-example::
 
-    .. versionadded:: 1.0
-        Description in title.
+    .. versionadded:: 1.0 Description in title.
+        :collapsible:
 
         Some additional context.
     .. versionchanged:: 2.0

--- a/docs/admonitions.rst
+++ b/docs/admonitions.rst
@@ -62,8 +62,9 @@ rendered by the sphinx-immaterial theme as admonitions.
 These admonition styles can be customized using the `Custom Admonitions`_ feature provided the
 :py:attr:`~sphinx_immaterial.custom_admonitions.CustomAdmonitionConfig.name` matches the directive
 name, but only the
-:py:attr:`~sphinx_immaterial.custom_admonitions.CustomAdmonitionConfig.icon` and
-:py:attr:`~sphinx_immaterial.custom_admonitions.CustomAdmonitionConfig.color` options will apply;
+:py:attr:`~sphinx_immaterial.custom_admonitions.CustomAdmonitionConfig.icon`,
+:py:attr:`~sphinx_immaterial.custom_admonitions.CustomAdmonitionConfig.color`, and
+:py:attr:`~sphinx_immaterial.custom_admonitions.CustomAdmonitionConfig.classes` options will apply;
 all other options are ignored.
 
 .. code-block:: py

--- a/docs/admonitions.rst
+++ b/docs/admonitions.rst
@@ -57,14 +57,16 @@ Version Directives
 ******************
 
 The `versionadded`, `versionchanged`, and `deprecated` directives defined by Sphinx are also
-overridden by the sphinx-immaterial theme to render as :rst:dir:`admonition`\ s with added
-functionality (like optionally making them :rst:`:collapsible:`).
+rendered by the sphinx-immaterial theme as admonitions. The directives are optionally
+overridden to support additional :rst:dir:`admonition` options :rst:`:collapsible:`,
+:rst:`:name:`, and :rst:`:class:`.
 
-Beware, these directive overrides do not support the :rst:`:title:` and
-:rst:`:no-title:` options because
+.. warning::
+   Beware, these directive overrides do not support the :rst:`:title:` and
+   :rst:`:no-title:` options because
 
-1. They require 1 argument (and optionally 1 additional argument) that gets used in the title.
-2. The default title cannot be changed.
+   1. They require 1 argument (and optionally 1 additional argument) that gets used in the title.
+   2. The default title cannot be changed.
 
 .. confval:: sphinx_immaterial_override_version_directives
 
@@ -76,8 +78,8 @@ Beware, these directive overrides do not support the :rst:`:title:` and
 
       sphinx_immaterial_override_version_directives = False
 
-These admonition styles can be customized (despite the
-:confval:`sphinx_immaterial_override_version_directives` value) using the `Custom Admonitions`_
+These admonition styles can be customized (regardless of the
+:confval:`sphinx_immaterial_override_version_directives` setting) using the `Custom Admonitions`_
 feature provided the
 :py:attr:`~sphinx_immaterial.custom_admonitions.CustomAdmonitionConfig.name` matches the directive
 name, but only the

--- a/docs/admonitions.rst
+++ b/docs/admonitions.rst
@@ -77,6 +77,11 @@ all other options are ignored.
         }
     ]
 
+Beware, these directives do not support the :rst:`:title:` and :rst:`:no-title:` options because
+
+1. They require 1 argument (and optionally 1 additional argument) that gets used in the title.
+2. The default title cannot be changed.
+
 .. rst-example::
 
     .. versionadded:: 1.0

--- a/sphinx_immaterial/custom_admonitions.css
+++ b/sphinx_immaterial/custom_admonitions.css
@@ -19,7 +19,8 @@
   background-color:rgb({{ admonition.color | join(',') }});
     {%- endif -%}
     {%- if admonition.icon is not none -%}
-  -webkit-mask-image:var(--si-icon--{{admonition.icon}});mask-image:var(--si-icon--{{admonition.icon}});}
+  -webkit-mask-image:var(--si-icon--{{admonition.icon}});mask-image:var(--si-icon--{{admonition.icon}});
     {%- endif -%}
+}
   {%- endif -%}
 {%- endfor -%}

--- a/sphinx_immaterial/custom_admonitions.py
+++ b/sphinx_immaterial/custom_admonitions.py
@@ -174,9 +174,7 @@ def visit_versionmodified(
         visit_collapsible(self, node, collapsible)
     else:
         # similar to what the OG visitor does but with an added admonition class
-        self.body.append(
-            self.starttag(node, "div", CLASSES=[node["type"], "admonition"])
-        )
+        self.body.append(self.starttag(node, "div", CLASSES=["admonition"]))
         # add admonition-title class to first paragraph
         node[0]["classes"].append("admonition-title")
 
@@ -214,15 +212,16 @@ class CustomVersionChange(VersionChange):
         ret = super().run()
         assert len(ret) and isinstance(ret[0], sphinx.addnodes.versionmodified)
         if "collapsible" in self.options:
+            if len(self.arguments) < 2:
+                raise self.error(
+                    "Expected 2 arguments before content in %s directive" % self.name
+                )
             self.assert_has_content()
             ret[0]["collapsible"] = self.options["collapsible"]
-        if "classes" not in self.options:
-            self.options["classes"] = []
+        if ret[0]["type"] not in ret[0]["classes"]:
+            ret[0]["classes"].append(ret[0]["type"])
         if "class" in self.options:
-            self.options["classes"].extend(self.options["class"])
-            del self.options["class"]
-        if self.options["classes"]:
-            ret[0]["classes"] += self.options["classes"]
+            ret[0]["classes"].extend(self.options["class"])
         self.add_name(ret[0])
         return ret
 

--- a/sphinx_immaterial/custom_admonitions.py
+++ b/sphinx_immaterial/custom_admonitions.py
@@ -494,7 +494,7 @@ def setup(app: Sphinx):
     app.add_config_value(
         name="sphinx_immaterial_override_version_directives",
         default=True,
-        rebuild="html",
+        rebuild="env",
         types=bool,
     )
 

--- a/sphinx_immaterial/custom_admonitions.py
+++ b/sphinx_immaterial/custom_admonitions.py
@@ -214,6 +214,7 @@ class CustomVersionChange(VersionChange):
         ret = super().run()
         assert len(ret) and isinstance(ret[0], sphinx.addnodes.versionmodified)
         if "collapsible" in self.options:
+            self.assert_has_content()
             ret[0]["collapsible"] = self.options["collapsible"]
         if "classes" not in self.options:
             self.options["classes"] = []


### PR DESCRIPTION
The version directives now support admonition options including `collapsible`, `class`, and `name`.

Note `title` and `no-title` options are not supported because
1. the default title cannot be changed
2. the directives arguments (both required and optional) are used in the title

The custom admonitions feature's `classes` option is now also respected when set in conf.py.