### PR TITLE
[docs] reorder palette color options

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -340,14 +340,15 @@ CSS_PALETTE_BUNDLE = (
 
 
 def get_colors(color_t: str):
-    unique_colors = {
-        m.group(1)
-        for m in re.finditer(
-            r"\[data-md-color-" + color_t + r"=([a-z\-]+)\]",
-            CSS_PALETTE_BUNDLE.read_text(encoding="utf-8"),
-        )
-    }
-    return sorted(unique_colors, key=lambda x: x.split("-")[-1])
+    unique_colors = []
+    for m in re.finditer(
+        r"\}\[data-md-color-"
+        + color_t
+        + r"=([a-z\-]+)\]\{.*?-fg-color:.*?;.*?-bg-color:.*?;",
+        CSS_PALETTE_BUNDLE.read_text(encoding="utf-8"),
+    ):
+        unique_colors.append(m.group(1))
+    return unique_colors
 
 
 jinja_contexts = {


### PR DESCRIPTION
This a follow up to #256 that orders the colors as they are listed in the CSS bundle (according to hue).

The previous ordering was a bit chaotic because it was grabbing the color names from rules specifically for hyperlink elements. But, by only grabbing the color names from rules that define the fg/bg color vars, we get the originally expected results. Using a `list` structure also helps preserve the order as a `set` doesn't seem to guarantee the same order in which the items were added.

![image](https://github.com/jbms/sphinx-immaterial/assets/14963867/f606bbab-a632-40ae-aca7-73d7f614f1d3)
![image](https://github.com/jbms/sphinx-immaterial/assets/14963867/35458bd1-a003-4375-82f6-b87c4b9608ab)
