### PR TITLE
update for pydantic v2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -449,6 +449,8 @@ nitpick_ignore = [
     # Example JavaScript types
     ("js:func", "string"),
     ("js:func", "SomeError"),
+    # pydantic_extra_types.color not present in object inventory
+    ("py:class", "pydantic_extra_types.color.Color"),
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 sphinx>=4.5
 markupsafe
-pydantic
+pydantic>=2.0
+pydantic-extra-types
 typing-extensions
 appdirs
 requests

--- a/requirements/dev-mypy.txt
+++ b/requirements/dev-mypy.txt
@@ -6,5 +6,6 @@ types-appdirs
 types-requests
 types-clang
 pytest
-pydantic
+pydantic>=2.0
+pydantic-extra-types
 sphinx>=4.5

--- a/sphinx_immaterial/apidoc/cpp/apigen.py
+++ b/sphinx_immaterial/apidoc/cpp/apigen.py
@@ -931,8 +931,11 @@ _CONFIG_ATTR = "_sphinx_immaterial_cpp_apigen_configs"
 def _config_inited(
     app: sphinx.application.Sphinx, config: sphinx.config.Config
 ) -> None:
-    apigen_configs = pydantic.parse_obj_as(
-        List[ApigenConfig], config.cpp_apigen_configs
+    apigen_configs = cast(
+        List[ApigenConfig],
+        pydantic.TypeAdapter(List[ApigenConfig]).validate_python(
+            config.cpp_apigen_configs
+        ),
     )
     setattr(app, _CONFIG_ATTR, apigen_configs)
 

--- a/sphinx_immaterial/custom_admonitions.css
+++ b/sphinx_immaterial/custom_admonitions.css
@@ -10,13 +10,13 @@
 {%- set name = '.' ~ admonition.name -%}
 {%- set icon = '' ~ admonition.icon ~ ');' -%}
   {%- if admonition.color is not none -%}
-.md-typeset .admonition{{name}}{border-color:rgb({{ admonition.color | join(',') }});}
-.md-typeset {{name}}>.admonition-title{background-color:rgba({{ admonition.color | join(',') }},0.1);border-color:rgb({{ admonition.color | join(',') }});}
+.md-typeset .admonition{{name}}{border-color:rgb({{ admonition.color.as_rgb_tuple(alpha=False) | join(',') }});}
+.md-typeset {{name}}>.admonition-title{background-color:rgba({{ admonition.color.as_rgb_tuple(alpha=False) | join(',') }},0.1);border-color:rgb({{ admonition.color.as_rgb_tuple(alpha=False) | join(',') }});}
   {%- endif -%}
   {%- if admonition.color is not none or admonition.icon is not none -%}
 .md-typeset {{name}}>.admonition-title::before{
     {%- if admonition.color is not none -%}
-  background-color:rgb({{ admonition.color | join(',') }});
+  background-color:rgb({{ admonition.color.as_rgb_tuple(alpha=False) | join(',') }});
     {%- endif -%}
     {%- if admonition.icon is not none -%}
   -webkit-mask-image:var(--si-icon--{{admonition.icon}});mask-image:var(--si-icon--{{admonition.icon}});

--- a/sphinx_immaterial/custom_admonitions.py
+++ b/sphinx_immaterial/custom_admonitions.py
@@ -126,7 +126,7 @@ class CustomAdmonitionConfig(pydantic.BaseModel):
 
     @pydantic.field_validator("name", mode="before")
     @classmethod
-    def validate_name(cls, val, info: pydantic.FieldValidationInfo):
+    def validate_name(cls, val):
         illegal = re.findall(r"([^a-zA-Z0-9\-_])", val)
         if illegal:
             raise ValueError(


### PR DESCRIPTION
resolves #268 

Also improves the color specification for custom admonitions by using the new `pydantic-extra-types` pkg. This means that the admonition color can be defined using a value compliant with CSS3 specs. Color transparency is ignored since all admonitions' colors use the same transparency (where applicable).

Pinned pydantic dependency to v2.0+ due to backward-incompatible changes (and better performance).