### PR TITLE
include recommended assets for mathjax

### DIFF
--- a/tools/build/index.ts
+++ b/tools/build/index.ts
@@ -136,7 +136,7 @@ const assets$ = concat(
     })),
 
   /* Copy mathjax dist */
-  ...["tex-mml-chtml.js", "output/chtml/fonts/woff-v2/*.woff", "../LICENSE"]
+  ...["tex-mml-chtml.js", "input/tex/extensions/*.js", "output/*.js", "output/**/*.js", "output/chtml/fonts/woff-v2/*.woff", "a11y/*.js", "sre/**/*.json", "../LICENSE"]
     .map(pattern => copyAll(pattern, {
       from: "node_modules/mathjax/es5",
       to: `${base}/bundles/mathjax`


### PR DESCRIPTION
resolves #279

Now includes all mathjax-needed files in the dist. This will also fix other features in the mathjax that optionally enabled (svg rendering).