### PR TITLE
force all objinfo icons to visually account for text's descender

### DIFF
--- a/sphinx_immaterial/nav_adapt.py
+++ b/sphinx_immaterial/nav_adapt.py
@@ -461,7 +461,7 @@ def _add_domain_info_to_toc(
             title_prefix = (
                 f'<span aria-label="{label}" '
                 f'class="objinfo-icon objinfo-icon__{toc_icon_class}" '
-                f'title="{label}">{toc_icon_text}</span>'
+                f'title="{label}">{toc_icon_text|upper}</span>'
             )
         span_prefix = "<span "
         assert entry.title.startswith(span_prefix)

--- a/sphinx_immaterial/nav_adapt.py
+++ b/sphinx_immaterial/nav_adapt.py
@@ -461,7 +461,7 @@ def _add_domain_info_to_toc(
             title_prefix = (
                 f'<span aria-label="{label}" '
                 f'class="objinfo-icon objinfo-icon__{toc_icon_class}" '
-                f'title="{label}">{toc_icon_text.upper()}</span>'
+                f'title="{label}">{toc_icon_text}</span>'
             )
         span_prefix = "<span "
         assert entry.title.startswith(span_prefix)

--- a/sphinx_immaterial/nav_adapt.py
+++ b/sphinx_immaterial/nav_adapt.py
@@ -461,7 +461,7 @@ def _add_domain_info_to_toc(
             title_prefix = (
                 f'<span aria-label="{label}" '
                 f'class="objinfo-icon objinfo-icon__{toc_icon_class}" '
-                f'title="{label}">{toc_icon_text|upper}</span>'
+                f'title="{label}">{toc_icon_text.upper()}</span>'
             )
         span_prefix = "<span "
         assert entry.title.startswith(span_prefix)

--- a/src/assets/stylesheets/main/_api.scss
+++ b/src/assets/stylesheets/main/_api.scss
@@ -239,7 +239,7 @@ $objinfo-icon-size: 16px;
 }
 
 .objinfo-icon {
-  display: inline-block;
+  display: inline-table;
   flex-shrink: 0;
   width: $objinfo-icon-size;
   height: $objinfo-icon-size;


### PR DESCRIPTION
Fix #289 

| before                                                                                              	| after                                                                                               	|
|-----------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------	|
| ![](https://github.com/jbms/sphinx-immaterial/assets/12596392/21ba1f5a-8f7f-4260-ba39-32f18e69910d) 	| ![](https://github.com/jbms/sphinx-immaterial/assets/12596392/7103fc77-0d72-4928-b0ea-84ed90bcfe11) 	|


