### PR TITLE
update namespace for pydantic API v2.5

### DIFF
--- a/sphinx_immaterial/custom_admonitions.py
+++ b/sphinx_immaterial/custom_admonitions.py
@@ -43,7 +43,7 @@ _CUSTOM_ADMONITIONS_KEY = "sphinx_immaterial_custom_admonitions"
 
 
 CSSClassType = Annotated[
-    str, pydantic.functional_validators.AfterValidator(nodes.make_id)
+    str, pydantic.AfterValidator(nodes.make_id)
 ]
 
 # defaults used for version directives re-styling


### PR DESCRIPTION
Apparently this is backward compatible to v2.2, so there's no need to update our pinned pydantic version.

resolves #302