### PR TITLE
Patch test deps for sphinx v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
         sphinx-version:
           - 'sphinx4'
           - 'sphinx5'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
             python-version: '3.10'
           - nox-sessions: 'mypy pylint'
             python-version: '3.11'
+          - nox-sessions: 'mypy pylint'
+            python-version: '3.12'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node.js

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ nox.options.sessions = [
     "check_lf",
 ]
 
-SUPPORTED_PY_VER = list(f"3.{x}" for x in range(8, 12))
+SUPPORTED_PY_VER = list(f"3.{x}" for x in range(8, 13))
 
 
 @nox.session

--- a/noxfile.py
+++ b/noxfile.py
@@ -211,6 +211,9 @@ def tests(session: nox.Session, sphinx: str):
     if not list(pathlib.Path().glob("sphinx_immaterial/*.html")):
         session.run("npm", "run", "build", external=True)
     session.install(f"sphinx{sphinx}")
+    if sphinx.endswith("<5"):
+        # sphinxcontrib deps that dropped support for sphinx v4.x
+        session.install("-r", "tests/requirements-sphinx4.txt")
     session.install("-r", "tests/requirements.txt")
     session.run("coverage", "run", "-m", "pytest", "-vv", "-s")
     # session.notify("docs") <- only calls docs(html), not dirhtml or latex builders

--- a/requirements/dev-mypy.txt
+++ b/requirements/dev-mypy.txt
@@ -1,4 +1,4 @@
-mypy==1.5.1
+mypy==1.8.0
 types-PyYAML
 docutils-stubs
 types-beautifulsoup4

--- a/requirements/dev-pylint.txt
+++ b/requirements/dev-pylint.txt
@@ -1,4 +1,4 @@
-pylint==2.17.5
+pylint==3.0.3
 
 -r ./cpp.txt
 -r ./json.txt

--- a/tests/requirements-sphinx4.txt
+++ b/tests/requirements-sphinx4.txt
@@ -1,0 +1,6 @@
+# The following version specs describe dependencies of sphinx that dropped support for sphinx v4.x
+sphinxcontrib-applehelp<1.0.5
+sphinxcontrib-devhelp<1.0.3
+sphinxcontrib-htmlhelp<2.0.2
+sphinxcontrib-serializinghtml<1.1.6
+sphinxcontrib-qthelp<1.0.4


### PR DESCRIPTION
fixes installed dependencies for tests using sphinx v4.x

Alternatively, we could deprecate sphinx v4, but I thought this would be more suitable for backward compatibility.

Also now includes python v3.12 in CI and unit tests.