### PR TITLE
create dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # recursive; requirements.txt in subdirectories are also monitored
+    schedule:
+      interval: "weekly"
+  # node.js dependencies are pinned to last merge from upstream.
+  # - package-ecosystem: "npm"
+  #   directory: "/" # Location of package manifests
+  #   schedule:
+  #     interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/" # auto-scans .github/workflows/*.yml
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: "/" # recursive; requirements.txt in subdirectories are also monitored
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: sphinxcontrib-*help
+      - dependency-name: sphinxcontrib-serializinghtml
   # node.js dependencies are pinned to last merge from upstream.
   # - package-ecosystem: "npm"
   #   directory: "/" # Location of package manifests


### PR DESCRIPTION
To automate updates for some dependencies, this PR enables github's dependabot for pip requirements.txt files and github actions used in CI workflows.

See [GH docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) for more detail.