### PR TITLE
bump actions/checkout from 3 to 4; fix pypa/gh-action-pypi-publish warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           - nox-sessions: 'mypy pylint'
             python-version: '3.12'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
         if: contains(matrix, 'node-version')
         uses: actions/setup-node@v4
@@ -81,7 +81,7 @@ jobs:
           - '16.x'
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Need full history to determine version number.
           fetch-depth: 0
@@ -165,7 +165,7 @@ jobs:
             sphinx-version: 'sphinx7'
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -205,7 +205,7 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download all artifacts
         uses: actions/download-artifact@v3
         with:
@@ -278,7 +278,7 @@ jobs:
           user: __token__
           password: ${{ secrets.pypi_token }}
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       - name: Create a Github Release
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_test_token }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
         if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
       - name: Publish to PyPI (main server)
         uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf # v1.8.11

--- a/setup.py
+++ b/setup.py
@@ -174,6 +174,7 @@ setuptools.setup(
     name="sphinx_immaterial",
     description="Adaptation of mkdocs-material theme for the Sphinx documentation system",
     long_description=pathlib.Path("README.rst").read_text(encoding="utf-8"),
+    long_description_content_type="text/x-rst",
     author="Jeremy Maitin-Shepard",
     author_email="jeremy@jeremyms.com",
     url="https://github.com/jbms/sphinx-immaterial",


### PR DESCRIPTION
- v4 of the actions/checkout uses node.js v20; v3 uses node.js v16. GH deprecated actions that use node.js v16.
- Includes minor fixes to avoid warnings from pypa/gh-action-pypi-publish (follow up to #316).