### PR TITLE
actions/download-artifact now supports a pattern

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,6 +210,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: ci-artifacts
+          pattern: coverage-data-*
       - run: mv ci-artifacts/**/.coverage* ./
       - name: Setup python
         uses: actions/setup-python@v5


### PR DESCRIPTION
This should reduce the time it takes to download the coverage data from a multitude of test runs. By using the action's new `pattern` input as the artifact name, we avoid downloading artifacts of docs builds.