### PR TITLE
Support methods/properties/functions that are aliased

### DIFF
--- a/docs/tensorstore_demo/__init__.py
+++ b/docs/tensorstore_demo/__init__.py
@@ -241,6 +241,8 @@ Overload:
 
 
         """
+    size_alias = size
+
     __hash__ = None
     pass
 class DimExpression():

--- a/docs/tensorstore_demo/_tensorstore.py
+++ b/docs/tensorstore_demo/_tensorstore.py
@@ -34,6 +34,9 @@ def bar(x: Foo) -> Foo:
     pass
 
 
+bar_also = bar
+
+
 class FooSubclass(Foo):
     """This is a subclass of :py:obj:`.Foo`.
 

--- a/sphinx_immaterial/apidoc/python/parameter_objects.py
+++ b/sphinx_immaterial/apidoc/python/parameter_objects.py
@@ -306,6 +306,7 @@ def _add_parameter_documentation_ids(
         # Identical declarations in more than one signature will only be
         # included once.
         unique_decls: Dict[str, Tuple[int, docutils.nodes.Element]] = {}
+        unique_symbols: Dict[Tuple[str, str], int] = {}
         for i, sig_param_nodes in enumerate(sig_param_nodes_for_signature):
             desc_param_node = sig_param_nodes.get(param_name)
             if desc_param_node is None:
@@ -313,6 +314,7 @@ def _add_parameter_documentation_ids(
             desc_param_node = cast(docutils.nodes.Element, desc_param_node)
             decl_text = desc_param_node.astext().strip()
             unique_decls.setdefault(decl_text, (i, desc_param_node))
+            unique_symbols.setdefault((decl_text, symbols[i]), i)
         if not unique_decls:
             all_params = {}
             for sig_param_nodes in sig_param_nodes_for_signature:
@@ -342,7 +344,7 @@ def _add_parameter_documentation_ids(
             param_symbols = set()
 
             # Set ids of the parameter node.
-            for symbol_i, _ in unique_decls.values():
+            for symbol_i in unique_symbols.values():
                 symbol = symbols[symbol_i]
                 param_symbol = f"{symbol}.{param_name}"
                 if param_symbol in param_symbols:

--- a/tests/python_apigen_test.py
+++ b/tests/python_apigen_test.py
@@ -138,5 +138,11 @@ def test_pure_python_property(apigen_make_app):
 
     data = _get_api_data(app.env)
 
-    options = data.entities[f"{testmod}.Example.foo"].options
+    entity = data.entities[f"{testmod}.Example.foo"]
+    assert entity.primary_entity
+    assert entity.siblings is not None
+    assert len(entity.siblings) == 1
+    assert entity.siblings[0].name == "bar"
+    options = entity.options
+
     assert options["type"] == "int"

--- a/tests/python_apigen_test_modules/property.py
+++ b/tests/python_apigen_test_modules/property.py
@@ -2,3 +2,5 @@ class Example:
     @property
     def foo(self) -> int:
         return 42
+
+    bar = foo


### PR DESCRIPTION
Previously, if the same function, method or property was assigned to an additional name in the same scope, it was documented as an independent entity.

With this change, it is documented together with the entity that it aliases as an additional signature.