### PR TITLE
python/apigen: Fix inheritance of sibling/alias members

### DIFF
--- a/tests/python_apigen_test.py
+++ b/tests/python_apigen_test.py
@@ -142,7 +142,18 @@ def test_pure_python_property(apigen_make_app):
     assert entity.primary_entity
     assert entity.siblings is not None
     assert len(entity.siblings) == 1
-    assert entity.siblings[0].name == "bar"
-    options = entity.options
+    assert list(entity.siblings) == [f"{testmod}.Example.bar"]
 
+    options = entity.options
     assert options["type"] == "int"
+
+    entity = data.entities[f"{testmod}.InheritsFromExample"]
+    assert len(entity.members) == 2
+    member = entity.members[0]
+    assert member.name == "foo"
+    assert len(member.siblings) == 0
+
+    member = entity.members[1]
+    assert member.name == "baz"
+    assert len(member.siblings) == 1
+    assert member.siblings[0].name == "bar"

--- a/tests/python_apigen_test_modules/property.py
+++ b/tests/python_apigen_test_modules/property.py
@@ -4,3 +4,9 @@ class Example:
         return 42
 
     bar = foo
+
+
+class InheritsFromExample(Example):
+    foo = "abc"  # type: ignore[assignment]
+
+    baz = Example.bar


### PR DESCRIPTION
Previously, if class ``A`` defined a member ``p`` with an alias ``q``, and then ``B`` inherits from ``A``, the ``q`` alias would be listed twice, since it would be added when processing the members of ``A`` and then again when processing the members of ``B``..