### PR TITLE
unpin libclang on mac

### DIFF
--- a/requirements/cpp.txt
+++ b/requirements/cpp.txt
@@ -1,3 +1,1 @@
-# https://github.com/sighingnow/libclang/issues/71
-libclang < 17 ; sys_platform == 'darwin'
-libclang ; sys_platform != 'darwin'
+libclang


### PR DESCRIPTION
sighingnow/libclang#71 seems to have been resolved. I'm unpinning libclang for MacOS.