### PR TITLE
Improve coverage reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,12 @@ jobs:
         with:
           name: doc-builds-${{ runner.os }}
           path: docs/_build/
+      - name: upload docs to github pages
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && runner.os == 'Linux'
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # pinned to v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html
 
   test:
     needs: [check_conventions, build]
@@ -217,7 +223,13 @@ jobs:
           name: coverage-report
           path: htmlcov/
       - name: Post coverage summary
-        run: cat .coverage_.md >> $GITHUB_STEP_SUMMARY
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)
 
   compare-wheels:
     runs-on: ubuntu-latest
@@ -279,18 +291,3 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release create ${{ github.ref_name }} --generate-notes
-      - name: Download docs artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: doc-builds-${{ runner.os }}
-          path: docs/_build/html
-      - name: Download coverage report artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-report
-          path: docs/_build/html/coverage_report/
-      - name: upload docs to github pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # pinned to v4.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/_build/html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,12 +130,6 @@ jobs:
         with:
           name: doc-builds-${{ runner.os }}
           path: docs/_build/
-      - name: upload docs to github pages
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && runner.os == 'Linux'
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # pinned to v4.0.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/_build/html
 
   test:
     needs: [check_conventions, build]
@@ -258,7 +252,7 @@ jobs:
     # Only publish package on push to tag or default branch.
     if: ${{ github.event_name == 'push' && github.repository == 'jbms/sphinx-immaterial' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
-    needs: [build, test]
+    needs: [build, coverage-report]
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -285,3 +279,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release create ${{ github.ref_name }} --generate-notes
+      - name: Download docs artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: doc-builds-${{ runner.os }}
+          path: docs/_build/html
+      - name: Download coverage report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: docs/_build/html/coverage_report/
+      - name: upload docs to github pages
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # pinned to v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Sphinx-Immaterial Theme
 =======================
 
-|MIT License| |PyPI Package| |CI status|
+|MIT License| |PyPI Package| |CI status| |codecov-badge|
 
 This theme is an adaptation of the popular `mkdocs-material
 <https://github.com/squidfunk/mkdocs-material/>`__ theme for the `Sphinx
@@ -118,3 +118,7 @@ few differences, primarily due to differences between Sphinx and MkDocs:
 
 .. |CI status| image:: https://github.com/jbms/sphinx-immaterial/actions/workflows/build.yml/badge.svg
    :target: https://github.com/jbms/sphinx-immaterial/actions/workflows/build.yml
+
+.. |codecov-badge| image:: https://codecov.io/gh/jbms/sphinx-immaterial/graph/badge.svg?token=IGK0B3WN42
+   :alt: codecov
+   :target: https://codecov.io/gh/jbms/sphinx-immaterial

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    patch:
+      default:
+        informational: true
+    project:
+      default:
+        target: auto
+        # adjust accordingly based on how flaky your tests are
+        # this allows a 2% drop from the previous base commit coverage
+        threshold: 2%

--- a/docs/apidoc/json/domain.rst
+++ b/docs/apidoc/json/domain.rst
@@ -77,7 +77,7 @@ specifying the JSON schema definition files.
       :caption: Setting default roles and highlight language in :file:`conf.py`
 
       rst_prolog = """
-      .. role json(code)
+      .. role:: json(code)
          :language: json
          :class: highlight
       """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,6 +172,11 @@ html_theme_options = {
             "title": "Github Pages",
             "aliases": [],
         },
+        {
+            "version": "https://jbms.github.io/sphinx-immaterial/coverage_report",
+            "title": "Coverage Report",
+            "aliases": [],
+        },
     ],
     # END: version_dropdown
     "toc_title_is_page_title": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,11 +172,6 @@ html_theme_options = {
             "title": "Github Pages",
             "aliases": [],
         },
-        {
-            "version": "https://jbms.github.io/sphinx-immaterial/coverage_report",
-            "title": "Coverage Report",
-            "aliases": [],
-        },
     ],
     # END: version_dropdown
     "toc_title_is_page_title": True,

--- a/noxfile.py
+++ b/noxfile.py
@@ -215,7 +215,7 @@ def tests(session: nox.Session, sphinx: str):
         # sphinxcontrib deps that dropped support for sphinx v4.x
         session.install("-r", "tests/requirements-sphinx4.txt")
     session.install("-r", "tests/requirements.txt")
-    session.run("coverage", "run", "-m", "pytest", "-vv", "-s")
+    session.run("coverage", "run", "-m", "pytest", "-vv", "-s", "--durations=5")
     # session.notify("docs") <- only calls docs(html), not dirhtml or latex builders
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -230,5 +230,5 @@ def coverage(session: nox.Session):
         f"<details><summary>Coverage is {total}%</summary>\n\n{md}\n\n</details>",
         encoding="utf-8",
     )
-    session.run("coverage", "html")
+    session.run("coverage", "xml")
     session.log("Coverage is %d%%", total)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,23 @@ omit = [
 
 [tool.coverage.report]
 skip_empty = true
+# Regexes for lines to exclude from consideration
+exclude_lines = [
+    # Have to re-enable the standard pragma
+    "pragma: no cover",
+    # Don't complain about missing debug-only code:
+    "def __repr__",
+    # the point of unit tests is to test parts of main()
+    "def main",
+    # ignore any branch that makes the module executable
+    'if __name__ == "__main__"',
+    # ignore missing implementations
+    "raise NotImplementedError",
+    # ignore the type checking specific code (only executed by mypy)
+    "if typing.TYPE_CHECKING",
+    # ignore import errors for conditional deps (test run with a strict set of deps)
+    "except ImportError",
+]
 
 [tool.coverage.html]
 show_contexts = true

--- a/sphinx_immaterial/content_tabs.py
+++ b/sphinx_immaterial/content_tabs.py
@@ -172,7 +172,7 @@ def visit_tab_set(self: HTMLTranslator, node: content_tab_set):
 
 
 def depart_tab_set(self: HTMLTranslator, node: content_tab_set):
-    pass
+    pass  # pragma: no cover
 
 
 def setup(app: Sphinx):

--- a/sphinx_immaterial/inlinesyntaxhighlight.py
+++ b/sphinx_immaterial/inlinesyntaxhighlight.py
@@ -73,7 +73,8 @@ def _monkey_patch_html_translator(translator_class):
         if "code" not in node["classes"] or not lang:
             return orig_visit_literal(self, node)
 
-        def warner(msg):
+        # This isn't used by pygments; it may be for a different highlighter
+        def warner(msg):  # pragma: no cover
             self.builder.warn(msg, (self.builder.current_docname, node.line))
 
         highlight_args = dict(node.get("highlight_args", {}), nowrap=True)

--- a/tests/admonition_test.py
+++ b/tests/admonition_test.py
@@ -1,0 +1,127 @@
+"""Tests related to theme's patched admonitions."""
+
+import pytest
+from sphinx.testing.util import SphinxTestApp
+from sphinx.errors import ExtensionError
+
+conf = [
+    {
+        "name": "legacy",
+        "color": (236, 64, 11),
+        "icon": "fontawesome/solid/recycle",
+        "classes": ["custom-class"],
+    },
+    {
+        "name": "attention",
+        "classes": ["important"],
+    },
+    {
+        "name": "versionremoved",
+        "classes": ["warning"],
+        "override": True,
+    },
+    {
+        "name": "deprecated",
+        "color": (0, 0, 0),
+        "override": True,
+    },
+    {
+        # This is impractical, but it covers a condition in production code
+        "name": "versionchanged",
+        "override": True,
+    },
+]
+
+
+def test_admonitions(immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        extra_conf=f"sphinx_immaterial_custom_admonitions={repr(conf)}",
+        files={
+            "index.rst": """
+The Test
+========
+
+.. deprecated:: 0.0.1 scheduled for removal
+
+.. versionremoved:: 0.1.0 Code was removed!
+    :collapsible: open
+    :class: custom-class
+
+    Some rationale.
+
+.. legacy::
+    :collapsible: open
+    :class: custom-class
+
+    Some content.
+
+.. legacy:: A
+    :title: Custom title
+
+    Some content.
+
+""",
+        },
+    )
+
+    app.build()
+    assert not app._warning.getvalue()  # type: ignore[attr-defined]
+
+
+def test_admonition_name_error(immaterial_make_app):
+    # both exceptions must be raised here, so signify this using nested with statements
+    with pytest.raises(ExtensionError):
+        with pytest.raises(ValueError):
+            immaterial_make_app(
+                extra_conf="sphinx_immaterial_custom_admonitions=[{"
+                '"name":"legacy!","classes":["note"]}]',
+                files={
+                    "index.rst": "",
+                },
+            )
+
+
+def test_admonitions_warnings(immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        files={
+            "index.rst": """
+The Test
+========
+
+.. note::
+    :collapsible:
+    :no-title:
+
+    Some content.
+
+.. deprecated:: 0.1.0
+    :collapsible:
+    
+""",
+        },
+    )
+
+    app.build()
+    warnings = app._warning.getvalue()  # type: ignore[attr-defined]
+    assert warnings
+    assert "title is needed for collapsible admonitions" in warnings
+    assert "Expected 2 arguments before content in deprecated directive" in warnings
+
+
+def test_todo_admonition(immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        extra_conf="extensions.append('sphinx.ext.todo')",
+        files={
+            "index.rst": """
+The Test
+========
+
+.. todo::
+    Some content.
+    
+""",
+        },
+    )
+
+    app.build()
+    assert not app._warning.getvalue()  # type: ignore[attr-defined]

--- a/tests/admonition_test.py
+++ b/tests/admonition_test.py
@@ -96,7 +96,7 @@ The Test
 
 .. deprecated:: 0.1.0
     :collapsible:
-    
+
 """,
         },
     )
@@ -118,7 +118,7 @@ The Test
 
 .. todo::
     Some content.
-    
+
 """,
         },
     )

--- a/tests/code_annotations_test.py
+++ b/tests/code_annotations_test.py
@@ -1,0 +1,50 @@
+"""Tests related to theme's code block annotations."""
+
+from sphinx.testing.util import SphinxTestApp
+
+index_rst = """
+The Test
+========
+
+.. code-block:: yaml
+    :caption: A caption for good measure
+
+    # (1)!
+
+.. code-annotations::
+    1. An annotation
+
+.. code-annotations::
+    #. A regular list not used in annotations.
+
+.. code-block:: python
+
+    # A normal code block without annotations
+"""
+
+
+def test_code_annotation(immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        files={"index.rst": index_rst},
+    )
+
+    app.build()
+    assert not app._warning.getvalue()  # type: ignore[attr-defined]
+
+def test_code_annotation_error(immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        files={
+            "index.rst": """
+The Test
+========
+
+.. code-annotations::
+    This is not an enumerated list!
+
+"""},
+    )
+
+    app.build()
+    warnings = app._warning.getvalue()  # type: ignore[attr-defined]
+    assert warnings
+    assert "The code-annotations directive only accepts an enumerated list" in warnings

--- a/tests/content_tabs_test.py
+++ b/tests/content_tabs_test.py
@@ -9,7 +9,7 @@ index_rst = """
 The Test
 ========
 
-.. md-tab-set:: 
+.. md-tab-set::
     :name: tab_set_ref
 
     .. md-tab-item:: A
@@ -40,7 +40,7 @@ def test_tab_set_child_error(immaterial_make_app):
 The Test
 ========
 
-.. md-tab-set:: 
+.. md-tab-set::
 
     This is not a ``md-tab-item``!
 """},

--- a/tests/content_tabs_test.py
+++ b/tests/content_tabs_test.py
@@ -1,0 +1,70 @@
+"""Tests related to theme's content tabs."""
+
+from docutils.nodes import Node
+import pytest
+from sphinx.testing.util import SphinxTestApp
+from sphinx_immaterial.content_tabs import is_md_tab_type
+
+index_rst = """
+The Test
+========
+
+.. md-tab-set:: 
+    :name: tab_set_ref
+
+    .. md-tab-item:: A
+
+        Tab A content
+
+    .. md-tab-item:: B
+
+        Tab B content
+"""
+
+
+def test_content_tabs(immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        files={"index.rst": index_rst},
+    )
+
+    app.build()
+    assert not app._warning.getvalue()  # type: ignore[attr-defined]
+
+def test_tab_ext_error():
+    assert not is_md_tab_type(Node(), "")
+
+def test_tab_set_child_error(immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        files={
+            "index.rst": """
+The Test
+========
+
+.. md-tab-set:: 
+
+    This is not a ``md-tab-item``!
+"""},
+    )
+
+    with pytest.raises(ValueError):
+        app.build()
+        warnings = app._warning.getvalue()  # type: ignore[attr-defined]
+        assert warnings
+        assert "All children of a 'md-tab-set' should be 'md-tab-item'" in warnings
+
+def test_tab_item_parent_error(immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        files={
+            "index.rst": """
+The Test
+========
+
+.. md-tab-item:: Orphan
+
+    This is ``md-tab-item`` has no parent ``md-tab-set``!
+"""},
+    )
+    app.build()
+    warnings = app._warning.getvalue()  # type: ignore[attr-defined]
+    assert warnings
+    assert "The parent of a 'md-tab-item' should be a 'md-tab-set'" in warnings

--- a/tests/inline_icon_test.py
+++ b/tests/inline_icon_test.py
@@ -1,0 +1,61 @@
+"""Tests related to theme's inline icon extension."""
+
+from pathlib import Path
+import pytest
+from sphinx.testing.util import SphinxTestApp
+from sphinx_immaterial.inline_icons import get_custom_icons
+
+index_rst = """
+The Test
+========
+
+This icon :si-icon:`sphinx_logo;custom-class` is sourced from a third-party.
+"""
+
+sphinx_logo = Path(__file__).parent.parent / "docs" / "_static" / "sphinx_logo.svg"
+
+
+@pytest.mark.parametrize(
+    "custom_path", ["./", "./sub/path"], ids=["root", "nested_subdir"]
+)
+def test_custom_icon(custom_path: str, tmp_path: Path, immaterial_make_app):
+    (tmp_path / custom_path).mkdir(parents=True, exist_ok=True)
+    app: SphinxTestApp = immaterial_make_app(
+        extra_conf=f'sphinx_immaterial_icon_path = ["{custom_path}"]',
+        files={
+            "index.rst": index_rst,
+            f"{custom_path}/sphinx_logo.svg": sphinx_logo.read_text(encoding="utf-8"),
+        },
+    )
+    app.build()
+    assert not app._warning.getvalue()  # type: ignore[attr-defined]
+
+
+def test_bundled_icon_not_found(immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(files={"index.rst": index_rst})
+    with pytest.raises(FileNotFoundError):
+        app.build()
+
+
+def test_merge_env_icon_data(immaterial_make_app):
+    toc = """
+.. toctree::
+    :hidden:
+
+    self
+    and_more
+"""
+    app: SphinxTestApp = immaterial_make_app(
+        extra_conf='sphinx_immaterial_icon_path = ["./"]',
+        files={
+            "index.rst": "\n".join([toc, index_rst]),
+            "and_more.rst": index_rst + "\n:si-icon:`material/material-design`\n",
+            "sphinx_logo.svg": sphinx_logo.read_text(encoding="utf-8"),
+        },
+        parallel=2,
+    )
+    app.builder.read()
+    icon_data = get_custom_icons(app.env)
+    assert icon_data
+    assert "sphinx_logo" in icon_data
+    assert "material_material-design" in icon_data

--- a/tests/inline_syntax_highlight_test.py
+++ b/tests/inline_syntax_highlight_test.py
@@ -1,0 +1,71 @@
+"""Tests related to theme's syntax highlighting
+(default-literal inline and code-block)."""
+
+from sphinx.testing.util import SphinxTestApp
+import pytest
+
+rst_prologue = """.. role:: python(code)
+   :language: python
+   :class: highlight
+"""
+default_literal_rst = """
+The Test
+========
+
+Normal literal role: ``1 + 2``
+
+.. default-literal-role:: python
+
+Python literal role: ``1 + 2``
+
+.. default-literal-role::
+
+Normal literal role again: ``1 + 2``
+
+"""
+
+highlight_push_pop = """
+The Test
+========
+
+.. highlight-push::
+
+.. highlight:: json
+
+The following literal block will be highlighted as JSON::
+
+   {"a": 10, "b": null, "c": 10}
+
+.. highlight-push::
+
+.. highlight:: python
+
+The following block will be highlighted as Python::
+
+   def foo(x: int) -> None: ...
+
+.. highlight-pop::
+
+The following block will be highlighted as JSON::
+
+   [1, 2, true, false]
+"""
+
+
+@pytest.mark.parametrize(
+    "doc",
+    [
+        "\n".join([rst_prologue, default_literal_rst]),
+        pytest.param(default_literal_rst, marks=pytest.mark.xfail),
+        highlight_push_pop,
+    ],
+    ids=["default_literal", "default_literal_warning", "highlight_push_pop"],
+)
+def test_syntax_highlighting(doc: str, immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        extra_conf="extensions.append('sphinx_immaterial.inlinesyntaxhighlight')",
+        files={"index.rst": doc},
+    )
+
+    app.build()
+    assert not app._warning.getvalue()  # type: ignore[attr-defined]

--- a/tests/json_domain_test.py
+++ b/tests/json_domain_test.py
@@ -1,7 +1,57 @@
+from pathlib import Path
 import re
 
 import docutils.utils
+import pytest
 import sphinx.addnodes
+
+
+@pytest.mark.parametrize(
+    "doc,schema",
+    [
+        (
+            "\n".join(
+                [
+                    ".. json:schema:: Pet",
+                    ".. json:schema:: Dog",
+                    ".. json:schema:: Cat",
+                ]
+            ),
+            "docs/apidoc/json/inheritance_schema.yml",
+        ),
+        (
+            "\n".join(
+                [
+                    ".. json:schema:: IndexTransform",
+                    ".. json:schema:: OutputIndexMap",
+                    ".. json:schema:: IndexInterval",
+                ]
+            ),
+            "docs/apidoc/json/index_transform_schema.yml",
+        ),
+    ],
+    ids=["inheritance", "IndexTransform"],
+)
+def test_doc_examples(doc: str, schema: str, tmp_path: Path, immaterial_make_app):
+    schema_path = Path(__file__).parent.parent / schema
+    app = immaterial_make_app(
+        extra_conf='''
+extensions.append("sphinx_immaterial.apidoc.json.domain")
+json_schemas = ["schema.yml"]
+json_schema_validate = True
+rst_prolog = """
+.. role:: json(code)
+    :language: json
+    :class: highlight
+"""
+''',
+        files={
+            "index.rst": doc,
+            "schema.yml": schema_path.read_text(encoding="utf-8"),
+        },
+    )
+    app.build()
+    assert not app._warning.getvalue()
 
 
 def test_xref_source_info(immaterial_make_app):

--- a/tests/kbd_keys_test.py
+++ b/tests/kbd_keys_test.py
@@ -1,0 +1,32 @@
+"""Tests related to theme's kbd_keys extension."""
+
+import pytest
+from sphinx.testing.util import SphinxTestApp
+
+index_rst = """
+The Test
+========
+
+:keys:`ctrl+alt+tab`
+
+:keys:`caps-lock`, :keys:`left-cmd+shift+a`, :keys:`backspace`
+
+:keys:`my-special-key+My Special Key`
+"""
+
+
+@pytest.mark.parametrize("builder", ["html", "latex"])
+def test_keys_role(builder: str, immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        extra_conf="\n".join(
+            [
+                "extensions.append('sphinx_immaterial.kbd_keys')",
+                'keys_map = {"my-special-key": "Awesome Key"}',
+            ]
+        ),
+        files={"index.rst": index_rst},
+        buildername=builder,
+    )
+
+    app.build()
+    assert not app._warning.getvalue()  # type: ignore[attr-defined]

--- a/tests/mermaid_test.py
+++ b/tests/mermaid_test.py
@@ -1,0 +1,30 @@
+"""Tests related to theme's mermaid graphs extension."""
+
+import pytest
+from sphinx.testing.util import SphinxTestApp
+
+index_rst = """
+The Test
+========
+
+.. md-mermaid::
+    :name: flowcharts
+
+    graph LR
+        A[Start] --> B{Error?};
+        B -->|Yes| C[Hmm...];
+        C --> D[Debug];
+        D --> B;
+        B ---->|No| E[Yay!];
+"""
+
+
+@pytest.mark.parametrize("builder", ["html", "latex"])
+def test_mermaid_graph(builder: str, immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        files={"index.rst": index_rst},
+        buildername=builder,
+    )
+
+    app.build()
+    assert not app._warning.getvalue()  # type: ignore[attr-defined]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,4 +8,5 @@ tests/issue_134/sphinx-immaterial-pybind11-issue-134
 -r ../requirements.txt
 -r ../requirements/cpp.txt
 -r ../requirements/json.txt
+-r ../requirements/jsonschema_validation.txt
 -r ../requirements/keys.txt

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,3 +8,4 @@ tests/issue_134/sphinx-immaterial-pybind11-issue-134
 -r ../requirements.txt
 -r ../requirements/cpp.txt
 -r ../requirements/json.txt
+-r ../requirements/keys.txt

--- a/tests/sitemap_test.py
+++ b/tests/sitemap_test.py
@@ -1,0 +1,27 @@
+"""Tests related to theme's postprocess_html extension (which creates a sitemap)."""
+# TODO: sphinx_immaterial.postprocess_html does not support incremental builds.
+# This is adequate because docs are typically deployed from a fresh build.
+# However, this lacking implementation may impact versioned docs.
+
+from pathlib import Path
+from sphinx.testing.util import SphinxTestApp
+
+index_rst = """
+The Test
+========
+"""
+
+
+def test_create_sitemap(tmp_path: Path, immaterial_make_app):
+    url = "https://example.com/test"
+    app: SphinxTestApp = immaterial_make_app(
+        extra_conf=f'html_theme_options = {{"site_url": "{url}"}}',
+        files={"index.rst": index_rst},
+    )
+    app.build()
+    assert not app._warning.getvalue()  # type: ignore[attr-defined]
+    sitemap = tmp_path / "_build" / "html" / "sitemap.xml"
+    assert sitemap.exists()
+    sitemap_data = sitemap.read_text(encoding="utf-8")
+    for doc in ["index", "genindex"]:
+        assert f"{url}/{doc}.html" in sitemap_data

--- a/tests/sitemap_test.py
+++ b/tests/sitemap_test.py
@@ -1,7 +1,4 @@
 """Tests related to theme's postprocess_html extension (which creates a sitemap)."""
-# TODO: sphinx_immaterial.postprocess_html does not support incremental builds.
-# This is adequate because docs are typically deployed from a fresh build.
-# However, this lacking implementation may impact versioned docs.
 
 from pathlib import Path
 from sphinx.testing.util import SphinxTestApp

--- a/tests/task_list_test.py
+++ b/tests/task_list_test.py
@@ -1,0 +1,40 @@
+"""Tests related to theme's task list extension."""
+
+from sphinx.testing.util import SphinxTestApp
+
+index_rst = """
+The Test
+========
+
+.. task-list::
+    :name: task_list_example
+    :custom:
+
+    1. [x] Task A
+    2. [ ] Task B
+
+       .. task-list::
+           :clickable:
+
+           * [x] Task B1
+           * [x] Task B2
+           * [] Task B3
+
+           A rogue paragraph with a reference to
+           the `parent task_list <task_list_example>`.
+
+           - A list item without a checkbox.
+           - [ ] Another bullet point.
+
+    3. [ ] Task C
+"""
+
+
+def test_task_list(immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        extra_conf="extensions.append('sphinx_immaterial.task_lists')",
+        files={"index.rst": index_rst},
+    )
+
+    app.build()
+    assert not app._warning.getvalue()  # type: ignore[attr-defined]

--- a/tests/theme_result_test.py
+++ b/tests/theme_result_test.py
@@ -1,0 +1,36 @@
+"""Tests related to theme's theme_result extension."""
+
+from sphinx.testing.util import SphinxTestApp
+
+index_rst = """
+The Test
+========
+
+.. rst-example::
+
+    The directive content to showcase.
+
+.. rst-example:: A caption
+
+    The directive content to showcase.
+
+.. rst-example::
+    :output-prefix:
+
+    The directive content to showcase.
+
+.. rst-example::
+    :output-prefix: The above code renders the following result:
+
+    The directive content to showcase.
+"""
+
+
+def test_theme_result(immaterial_make_app):
+    app: SphinxTestApp = immaterial_make_app(
+        extra_conf="extensions.append('sphinx_immaterial.theme_result')",
+        files={"index.rst": index_rst},
+    )
+
+    app.build()
+    assert not app._warning.getvalue()  # type: ignore[attr-defined]


### PR DESCRIPTION
This adds unit tests for some of our simpler extensions. The `apidoc.*` and `external_resources` extensions still need some tests...

I mostly just used examples from the docs to create the new tests. This is a better measurement because unit tests are done in isolation, no other extensions complicate expected behavior.

I'm seeing a 7% increase in coverage in CI (compared to current main branch).

~As a continued avoidance of third-party services (like CodeCov), I also adjusted the CI workflow. Now, the coverage report's HTML output is uploaded to the gh-pages branch (in addition to Linux-built docs) upon push to main branch. Also, I added an entry to our docs' version selector for easy access to the latest coverage reports. This will help us see exactly which lines were invoked during unit tests (on main branch) without using `nox` locally.~

The pytest output will now show the top 5 longest running tests.
