### PR TITLE
Add support for Python type parameter lists

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -407,7 +407,10 @@ json_schema_rst_prolog = """
 .. highlight:: json
 """
 
-python_apigen_modules = {"tensorstore_demo": "python_apigen_generated/"}
+python_apigen_modules = {
+    "tensorstore_demo": "python_apigen_generated/",
+    "type_param_demo": "python_apigen_generated/",
+}
 
 python_apigen_default_groups = [
     ("class:.*", "Classes"),

--- a/docs/python_apigen_demo.rst
+++ b/docs/python_apigen_demo.rst
@@ -10,3 +10,8 @@ Some other group
 ----------------
 
 .. python-apigen-group:: some-other-group
+
+Type parameter demo
+-------------------
+
+.. python-apigen-group:: type-param

--- a/docs/tensorstore_demo/__init__.py
+++ b/docs/tensorstore_demo/__init__.py
@@ -735,8 +735,8 @@ class DimExpression():
             })
 
         More generally, specifying an ``n``-dimensional `bool` array is equivalent to
-        specifying ``n`` 1-dimensional index arrays, where the ``i``\ th index array specifies
-        the ``i``\ th coordinate of the `True` values:
+        specifying ``n`` 1-dimensional index arrays, where the ``i``\\ th index array specifies
+        the ``i``\\ th coordinate of the `True` values:
 
             >>> x = ts.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
             ...              dtype=ts.int32)
@@ -1049,8 +1049,8 @@ three cases:
           :python:`dims[i] = self.labels.index(other.labels[i])`.  It is an
           error if no such dimension exists.
 
-       2. Otherwise, ``i`` is the ``j``\ th unlabeled dimension of :python:`other`
-          (left to right), and :python:`dims[i] = k`, where ``k`` is the ``j``\ th
+       2. Otherwise, ``i`` is the ``j``\\ th unlabeled dimension of :python:`other`
+          (left to right), and :python:`dims[i] = k`, where ``k`` is the ``j``\\ th
           unlabeled dimension of :python:`self` (left to right).  It is an error
           if no such dimension exists.
 

--- a/docs/type_param_demo.py
+++ b/docs/type_param_demo.py
@@ -1,0 +1,122 @@
+import collections.abc
+from typing import (
+    TypeVar,
+    Generic,
+    overload,
+    Iterable,
+    Optional,
+    KeysView,
+    ValuesView,
+    ItemsView,
+    Iterator,
+    Union,
+)
+
+K = TypeVar("K")
+V = TypeVar("V")
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+class Map(Generic[K, V]):
+    """Maps keys of type :py:param:`.K` to values of type :py:param:`.V`.
+
+    Type parameters:
+      K:
+        Key type.
+      V:
+        Mapped value type.
+
+    Group:
+      type-param
+    """
+
+    @overload
+    def __init__(self): ...
+
+    @overload
+    def __init__(self, items: collections.abc.Mapping[K, V]): ...
+
+    @overload
+    def __init__(self, items: Iterable[tuple[K, V]]): ...
+
+    def __init__(self, items):
+        """Construct from the specified items."""
+        ...
+
+    def clear(self):
+        """Clear the map."""
+        ...
+
+    def keys(self) -> KeysView[K]:
+        """Return a dynamic view of the keys."""
+        ...
+
+    def items(self) -> ItemsView[K, V]:
+        """Return a dynamic view of the items."""
+        ...
+
+    def values(self) -> ValuesView[V]:
+        """Return a dynamic view of the values."""
+        ...
+
+    @overload
+    def get(self, key: K) -> Optional[V]: ...
+
+    @overload
+    def get(self, key: K, default: V) -> V: ...
+
+    @overload
+    def get(self, key: K, default: T) -> Union[V, T]: ...
+
+    def get(self, key: K, default=None):
+        """Return the mapped value, or the specified default."""
+        ...
+
+    def __len__(self) -> int:
+        """Return the number of items in the map."""
+        ...
+
+    def __contains__(self, key: K) -> bool:
+        """Check if the map contains :py:param:`.key`."""
+        ...
+
+    def __getitem__(self, key: K) -> V:
+        """Return the value associated with :py:param:`.key`.
+
+        Raises:
+          KeyError: if :py:param:`.key` is not present.
+        """
+        ...
+
+    def __setitem__(self, key: K, value: V):
+        """Set the value associated with the specified key."""
+        ...
+
+    def __delitem__(self, key: K):
+        """Remove the value associated with the specified key.
+
+        Raises:
+          KeyError: if :py:param:`.key` is not present.
+        """
+        ...
+
+    def __iter__(self) -> Iterator[K]:
+        """Iterate over the keys."""
+        ...
+
+
+class Derived(Map[int, U], Generic[U]):
+    """Map from integer keys to arbitrary values.
+
+    Type parameters:
+      U: Mapped value type.
+
+    Group:
+      type-param
+    """
+
+    pass
+
+
+__all__ = ["Map", "Derived"]

--- a/sphinx_immaterial/apidoc/format_signatures.py
+++ b/sphinx_immaterial/apidoc/format_signatures.py
@@ -405,7 +405,10 @@ def _format_signature_with_black(
             break
         if found_name:
             break
-        if isinstance(orig_child, sphinx.addnodes.desc_type_parameter_list):
+        if (
+            isinstance(orig_child, docutils.nodes.Element)
+            and orig_child.get("sphinx_immaterial_parent_type_parameter_list") is True
+        ):
             # This is the parent entity type parameter list added by apigen.
             parent_type_param_i = i
             break

--- a/sphinx_immaterial/apidoc/object_description_options.py
+++ b/sphinx_immaterial/apidoc/object_description_options.py
@@ -50,7 +50,22 @@ DEFAULT_OBJECT_DESCRIPTION_OPTIONS: List[Tuple[str, dict]] = [
     ("py:property", {"toc_icon_class": "alias", "toc_icon_text": "P"}),
     ("py:attribute", {"toc_icon_class": "alias", "toc_icon_text": "A"}),
     ("py:data", {"toc_icon_class": "alias", "toc_icon_text": "V"}),
-    ("py:parameter", {"toc_icon_class": "sub-data", "toc_icon_text": "p"}),
+    (
+        "py:parameter",
+        {
+            "toc_icon_class": "sub-data",
+            "toc_icon_text": "p",
+            "generate_synopses": "first_sentence",
+        },
+    ),
+    (
+        "py:typeParameter",
+        {
+            "toc_icon_class": "alias",
+            "toc_icon_text": "T",
+            "generate_synopses": "first_sentence",
+        },
+    ),
     ("c:member", {"toc_icon_class": "alias", "toc_icon_text": "V"}),
     ("c:var", {"toc_icon_class": "alias", "toc_icon_text": "V"}),
     ("c:function", {"toc_icon_class": "procedure", "toc_icon_text": "F"}),

--- a/sphinx_immaterial/apidoc/object_toc.py
+++ b/sphinx_immaterial/apidoc/object_toc.py
@@ -73,7 +73,6 @@ def _monkey_patch_toc_tree_process_doc():
         source: docutils.nodes.field,
     ) -> Optional[docutils.nodes.section]:
         fieldname = cast(docutils.nodes.field_name, source[0])
-        # fieldbody = cast(docutils.nodes.field_body, source[1])
         ids = fieldname["ids"]
         if not ids:
             # Not indexed

--- a/sphinx_immaterial/apidoc/python/object_ids.py
+++ b/sphinx_immaterial/apidoc/python/object_ids.py
@@ -123,9 +123,9 @@ def _monkey_patch_python_domain_to_support_object_ids():
                         if new_entry[2] == orig_node_id:
                             new_entry[2] = ""
                         new_entries.append(tuple(new_entry))
-                    cast(docutils.nodes.Element, self.indexnode)[
-                        "entries"
-                    ] = new_entries
+                    cast(docutils.nodes.Element, self.indexnode)["entries"] = (
+                        new_entries
+                    )
 
     PyObject.after_content = after_content  # type: ignore[assignment]
 

--- a/sphinx_immaterial/apidoc/python/synopses.py
+++ b/sphinx_immaterial/apidoc/python/synopses.py
@@ -21,15 +21,15 @@ def _monkey_patch_python_domain_to_add_object_synopses_to_references():
         obj = self.objects.get(name)
         if obj is None:
             return
-        refnode[
-            "reftitle"
-        ] = object_description_options.format_object_description_tooltip(
-            env,
-            object_description_options.get_object_description_options(
-                env, self.name, obj.objtype
-            ),
-            base_title=name,
-            synopsis=self.data["synopses"].get(name),
+        refnode["reftitle"] = (
+            object_description_options.format_object_description_tooltip(
+                env,
+                object_description_options.get_object_description_options(
+                    env, self.name, obj.objtype
+                ),
+                base_title=name,
+                synopsis=self.data["synopses"].get(name),
+            )
         )
 
     orig_resolve_xref = PythonDomain.resolve_xref

--- a/sphinx_immaterial/apidoc/python/type_param_utils.py
+++ b/sphinx_immaterial/apidoc/python/type_param_utils.py
@@ -1,0 +1,263 @@
+"""Utilities related to Python type parameter lists."""
+
+import sys
+import re
+import typing
+
+import sphinx
+from sphinx.util.inspect import safe_getattr
+import sphinx.util.typing
+
+
+TYPE_VAR_ANNOTATION_PREFIX = "__SPHINX_IMMATERIAL_TYPE_VAR__"
+"""Prefix used by monkey-patched `stringify_annotation` to indicate a TypeVar.
+
+This prefix is checked in a monkey-patched `type_to_xref` where it is converted
+into a parameter reference.
+"""
+
+
+if sys.version_info >= (3, 10):
+    TypeParam = typing.Union[typing.TypeVar, typing.ParamSpec]
+elif sys.version_info >= (3, 11):
+    TypeParam = typing.Union[typing.TypeVar, typing.TypeVarTuple, typing.ParamSpec]
+else:
+    TypeParam = typing.TypeVar
+
+
+def get_class_type_params(cls: type) -> tuple[TypeParam, ...]:
+    """Returns the ordered list of type parameters of a class."""
+
+    type_params = safe_getattr(cls, "__type_params__", ())
+    if type_params:
+        return type_params
+
+    origin = typing.get_origin(cls)
+    if origin is None:
+        origin = cls
+    if isinstance(origin, type) and not issubclass(origin, typing.Generic):  # type: ignore[arg-type]
+        return ()
+
+    args = typing.get_args(cls)
+    if args:
+        return tuple(arg for arg in args if isinstance(arg, TypeParam))  # type: ignore[misc,arg-type]
+
+    bases = safe_getattr(cls, "__orig_bases__", ())
+    if not bases:
+        bases = safe_getattr(cls, "__bases__", ())
+    if not bases:
+        return ()
+
+    # First check for `typing.Generic`, since that takes precedence.
+    for base in bases:
+        if typing.get_origin(base) is typing.Generic:
+            return typing.get_args(base)
+
+    params: dict[TypeParam, bool] = {}
+    for base in bases:
+        cur_params = get_class_type_params(base)
+        for param in cur_params:
+            params.setdefault(param, True)
+    return tuple(params)
+
+
+def stringify_type_params(type_params: typing.Iterable[TypeParam]) -> str:
+    """Convert a type parameter list to its string representation.
+
+    The string representation is suitable for embedding in a Python domain
+    signature.
+    """
+    if not type_params:
+        return ""
+    parts = ["["]
+    for i, param in enumerate(type_params):
+        if i != 0:
+            parts.append(",")
+        if isinstance(param, typing.TypeVar):
+            parts.append(param.__name__)
+            parts.append("")
+
+            if bound := param.__bound__:
+                parts.append(" : ")
+                parts.append(sphinx.util.typing.stringify_annotation(bound))
+            if constraints := param.__constraints__:
+                parts.append(" : (")
+                for j, constraint in enumerate(constraints):
+                    if j != 0:
+                        parts.append(", ")
+                    parts.append(sphinx.util.typing.stringify_annotation(constraint))
+                parts.append(")")
+    parts.append("]")
+    return "".join(parts)
+
+
+TypeParamSubstitutions = dict[str, str]
+
+
+def substitute_type_params(
+    stringified_annotation: str, substitutions: typing.Optional[TypeParamSubstitutions]
+) -> str:
+    if not substitutions:
+        return stringified_annotation
+    return _ENCODED_TYPE_PARAM_PATTERN.sub(
+        lambda m: substitutions.get(m[2], m[0]),
+        stringified_annotation,
+    )
+
+
+def _get_base_class_type_param_substitutions_impl(
+    cls: type,
+    substitutions: TypeParamSubstitutions,
+    base_classes: dict[type, TypeParamSubstitutions],
+):
+    bases = safe_getattr(cls, "__orig_bases__", ())
+    for base in bases:
+        base_origin = typing.get_origin(base) or base
+        if isinstance(base_origin, type) and not issubclass(
+            base_origin,
+            typing.Generic,  # type: ignore[arg-type]
+        ):
+            continue
+        if base_origin is typing.Generic:
+            continue
+        params = get_class_type_params(base_origin)
+        args = typing.get_args(base)
+
+        base_substitutions: TypeParamSubstitutions = {}
+
+        for param, arg in zip(params, args):
+            s_arg = substitute_type_params(
+                sphinx.util.typing.stringify_annotation(arg), substitutions
+            )
+            base_substitutions[param.__name__] = s_arg
+
+        base_classes.setdefault(base_origin, base_substitutions)
+
+        _get_base_class_type_param_substitutions_impl(
+            base_origin, base_substitutions, base_classes
+        )
+
+
+def get_base_class_type_param_substitutions(
+    cls: type,
+) -> dict[type, TypeParamSubstitutions]:
+    base_classes: dict[type, TypeParamSubstitutions] = {}
+    _get_base_class_type_param_substitutions_impl(cls, {}, base_classes)
+    return base_classes
+
+
+_ENCODE_TYPE_PARAM: dict[type[TypeParam], typing.Callable[[TypeParam], str]] = {
+    typing.TypeVar: lambda annotation: (
+        TYPE_VAR_ANNOTATION_PREFIX + "V_" + annotation.__name__
+    ),
+}
+_DECODE_TYPE_PARAM: dict[str, typing.Callable[[str], TypeParam]] = {
+    "V": typing.TypeVar,
+}
+
+if sys.version_info >= (3, 10):
+    _ENCODE_TYPE_PARAM[typing.ParamSpec] = (
+        lambda annotation: TYPE_VAR_ANNOTATION_PREFIX + "P_" + annotation.__name__
+    )
+    _DECODE_TYPE_PARAM["P"] = typing.ParamSpec
+if sys.version_info >= (3, 11):
+    _ENCODE_TYPE_PARAM[typing.TypeVarTuple] = (  # type: ignore[index]
+        lambda annotation: TYPE_VAR_ANNOTATION_PREFIX + "T_" + annotation.__name__
+    )
+    _DECODE_TYPE_PARAM["T"] = typing.TypeVarTuple  # type: ignore[assignment]
+
+
+_ENCODED_TYPE_PARAM_PATTERN = re.compile(
+    r"\b"
+    + TYPE_VAR_ANNOTATION_PREFIX
+    + "(["
+    + "".join(_DECODE_TYPE_PARAM.keys())
+    + r"])_(\w+)\b"
+)
+
+
+def decode_type_param(annotation: str) -> typing.Optional[TypeParam]:
+    m = _ENCODED_TYPE_PARAM_PATTERN.fullmatch(annotation)
+    if m is None:
+        return None
+    kind = m[1]
+    name = m[2]
+    decode = _DECODE_TYPE_PARAM[kind]
+    return decode(name)
+
+
+def encode_type_param(annotation: TypeParam) -> str:
+    return _ENCODE_TYPE_PARAM[type(annotation)](annotation)
+
+
+def get_type_params_from_signature(signature: str) -> dict[str, TypeParam]:
+    params = {}
+    for m in _ENCODED_TYPE_PARAM_PATTERN.finditer(signature):
+        name = m[2]
+        if name in params:
+            continue
+        kind = m[1]
+        decode = _DECODE_TYPE_PARAM[kind]
+        params[name] = decode(name)
+    return params
+
+
+def _monkey_patch_stringify_annotation_to_support_type_params():
+    """In order to properly resolve references to type parameters in signatures,
+    they need to be given the `py:param` role with a target of the unqualified
+    type name.
+
+    Normally, when `sphinx.ext.autodoc` encounters a TypeVar within a type
+    annotation, it formats it as `<module_name>.<type_name>`. As this is
+    indistinguishable from any other class name, our monkey-patched
+    `type_to_xref` would have no way to know when to create a `py:param`
+    reference instead of the usual `py:class` reference.
+
+    As a workaround, monkey-patch `stringify_annotation` to format `TypeVar`
+    annotations as `TYPE_VAR_ANNOTATION_PREFIX + type_name`. This special prefix
+    is then detected and stripped off by the monkey-patched `type_to_xref`
+    defined in type_annotation_transforms.py.
+    """
+    orig = sphinx.util.typing.stringify_annotation
+
+    def stringify_annotation(
+        annotation: typing.Any,
+        /,
+        mode="fully-qualified-except-typing",
+    ) -> str:
+        if (encode := _ENCODE_TYPE_PARAM.get(type(annotation))) is not None:
+            return encode(annotation)
+        return orig(annotation, mode=mode)
+
+    for module in [
+        "sphinx.util.typing",
+        "sphinx.ext.autodoc",
+        "sphinx.ext.autodoc.typehints",
+        "sphinx.util.inspect",
+        "sphinx.ext.napoleon.docstring",
+    ]:
+        m = sys.modules.get(module)
+        if m is None:
+            continue
+        if getattr(m, "stringify_annotation", None) is orig:
+            setattr(m, "stringify_annotation", stringify_annotation)
+
+    deprecated_objects = getattr(sphinx.util.typing, "_DEPRECATED_OBJECTS", {})
+    if "stringify" in deprecated_objects:
+        deprecated_objects["stringify"] = (stringify_annotation,) + deprecated_objects[
+            "stringify"
+        ][1:]
+
+
+if sphinx.version_info < (7, 1):
+    # Type parameters are not supported by Sphinx<7.1. Always just return an
+    # empty type parameter list.
+
+    def get_class_type_params(cls: type) -> tuple[TypeParam, ...]:
+        return ()
+
+    def get_type_params_from_signature(signature: str) -> dict[str, TypeParam]:
+        return {}
+
+else:
+    _monkey_patch_stringify_annotation_to_support_type_params()

--- a/tests/python_type_param_utils_test.py
+++ b/tests/python_type_param_utils_test.py
@@ -1,0 +1,49 @@
+import typing
+
+import pytest
+import sphinx
+from sphinx_immaterial.apidoc.python import type_param_utils
+
+if sphinx.version_info < (7, 1):
+    pytest.skip(
+        f"Type parameters not supported by Sphinx {sphinx.version_info}",
+        allow_module_level=True,
+    )
+
+
+T = typing.TypeVar("T")
+U = typing.TypeVar("U")
+
+
+class Foo(typing.Generic[T, U]):
+    pass
+
+
+class Bar1(Foo):
+    pass
+
+
+class Bar2(Foo, typing.Generic[U, T]):
+    pass
+
+
+class Bar3(Foo[int, T]):
+    pass
+
+
+def test_get_class_type_params():
+    assert type_param_utils.get_class_type_params(int) == ()
+    assert type_param_utils.get_class_type_params(Foo) == (T, U)
+    assert type_param_utils.get_class_type_params(Bar1) == (T, U)
+    assert type_param_utils.get_class_type_params(Bar2) == (U, T)
+    assert type_param_utils.get_class_type_params(Bar3) == (T,)
+
+
+def test_get_base_class_type_param_substitutions():
+    class Bar4(Bar3[tuple[U, int]]):
+        pass
+
+    assert type_param_utils.get_base_class_type_param_substitutions(Bar4) == {
+        Foo: {"T": "int", "U": "tuple[__SPHINX_IMMATERIAL_TYPE_VAR__V_U, int]"},
+        Bar3: {"T": "tuple[__SPHINX_IMMATERIAL_TYPE_VAR__V_U, int]"},
+    }


### PR DESCRIPTION
Sphinx has partial support for type parameter lists: they are supported by the Python domain in signatures, but are not supported by autodoc.

This adds the following support:

- Sphinx Python domain for type parameter fields in docstrings, with sphinx.ext.napoleon support as well.

- Support for type parameters as Sphinx objects, with cross-linking, like the existing support for function parameters as Sphinx objects.

- Support in apigen for PEP 695 type parameters, and for displaying pre-PEP 695 separately-defined TypeVar types as PEP 695 type parameters.