### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
       - main
   workflow_dispatch:
   schedule:
-    - cron: '0 0 1,16 * *'
+    - cron: "0 0 1,16 * *"
 
 jobs:
   check_conventions:
@@ -20,19 +20,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - nox-sessions: 'black check_yaml check_json check_toml check_eof check_trailing_space check_lf'
-            python-version: '3.x'
-            node-version: '16.x'
-          - nox-sessions: 'mypy pylint'
-            python-version: '3.8'
-          - nox-sessions: 'mypy pylint'
-            python-version: '3.9'
-          - nox-sessions: 'mypy pylint'
-            python-version: '3.10'
-          - nox-sessions: 'mypy pylint'
-            python-version: '3.11'
-          - nox-sessions: 'mypy pylint'
-            python-version: '3.12'
+          - nox-sessions: "black check_yaml check_json check_toml check_eof check_trailing_space check_lf"
+            python-version: "3.x"
+            node-version: "16.x"
+          - nox-sessions: "mypy pylint"
+            python-version: "3.9"
+          - nox-sessions: "mypy pylint"
+            python-version: "3.10"
+          - nox-sessions: "mypy pylint"
+            python-version: "3.11"
+          - nox-sessions: "mypy pylint"
+            python-version: "3.12"
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -71,13 +69,13 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - 'ubuntu-latest'
-          - 'windows-latest'
-          - 'macos-latest'
+          - "ubuntu-latest"
+          - "windows-latest"
+          - "macos-latest"
         python-version:
-          - '3.x'
+          - "3.x"
         node-version:
-          - '16.x'
+          - "16.x"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -116,7 +114,7 @@ jobs:
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c # v2.0.2
         with:
-          macos-skip-brew-update: 'true'
+          macos-skip-brew-update: "true"
       - uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/theme_build_cache
@@ -143,25 +141,21 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - 'ubuntu-latest'
-          - 'windows-latest'
-          - 'macos-latest'
+          - "ubuntu-latest"
+          - "windows-latest"
+          - "macos-latest"
         python-version:
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
-          - '3.12'
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
         sphinx-version:
-          - 'sphinx4'
-          - 'sphinx5'
-          - 'sphinx6'
-          - 'sphinx7'
+          - "sphinx4"
+          - "sphinx5"
+          - "sphinx6"
+          - "sphinx7"
         node-version:
-          - '16.x'
-        exclude:
-          - python-version: '3.8'
-            sphinx-version: 'sphinx7'
+          - "16.x"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -183,7 +177,7 @@ jobs:
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c # v2.0.2
         with:
-          macos-skip-brew-update: 'true'
+          macos-skip-brew-update: "true"
       - uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/theme_build_cache
@@ -214,7 +208,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Create coverage report
         run: pipx run nox -s coverage
       - name: Upload comprehensive coverage HTML report

--- a/docs/test_py_module/test.py
+++ b/docs/test_py_module/test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Test Module for sphinx_rtd_theme."""
 import functools
-import sys
 from typing import Union
 
 
@@ -120,12 +119,10 @@ class Foo:
         """Return the instance qux as uppercase."""
         return self.capitalize(self.qux)
 
-    if sys.version_info >= (3, 8):
-
-        @functools.cached_property
-        def qux_caps_cached(self) -> str:
-            """Return the cached value of instance qux as uppercase."""
-            return self.qux_caps
+    @functools.cached_property
+    def qux_caps_cached(self) -> str:
+        """Return the cached value of instance qux as uppercase."""
+        return self.qux_caps
 
 
 def func(long: int, param: str, args: None, flags: bool, lists: Union[list, tuple]):

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ nox.options.sessions = [
     "check_lf",
 ]
 
-SUPPORTED_PY_VER = list(f"3.{x}" for x in range(8, 13))
+SUPPORTED_PY_VER = list(f"3.{x}" for x in range(9, 13))
 
 
 @nox.session

--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ setuptools.setup(
         ],
         "sphinx_immaterial.apidoc.cpp.cppreference_data": ["*.xml"],
     },
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=REQUIREMENTS,
     use_scm_version={
         # It would be nice to include the commit hash in the version, but that


### PR DESCRIPTION
While Python 3.8 is not officially EOL, NumPy dropped Python 3.8 support with NumPy 1.25 released Jun 2023.

https://numpy.org/news/#numpy-1250-released