### PR TITLE
json: Fix bug with specifying maxItems but not minItems

### DIFF
--- a/sphinx_immaterial/apidoc/json/domain.py
+++ b/sphinx_immaterial/apidoc/json/domain.py
@@ -597,10 +597,10 @@ class JsonSchemaDirective(sphinx.directives.ObjectDescription):
             if schema_node.get("minItems") == schema_node.get("maxItems"):
                 prefix.append(_json_literal(self.state, schema_node["minItems"]))
             else:
-                if schema_node["minItems"]:
+                if schema_node.get("minItems"):
                     prefix.append(_json_literal(self.state, schema_node["minItems"]))
                 prefix.append(sphinx.addnodes.desc_sig_punctuation("", ".."))
-                if schema_node["maxItems"]:
+                if "maxItems" in schema_node:
                     prefix.append(_json_literal(self.state, schema_node["maxItems"]))
             prefix.append(sphinx.addnodes.desc_sig_punctuation("", "]"))
 

--- a/tests/json_domain_test.py
+++ b/tests/json_domain_test.py
@@ -116,3 +116,26 @@ allOf:
         r"schema\.yml:4: ERROR: Reference to undefined JSON schema: 'OtherSchema'",
         app._warning.getvalue(),
     )
+
+
+def test_minitems_without_maxitems(immaterial_make_app):
+    app = immaterial_make_app(
+        extra_conf="\n".join(
+            [
+                'extensions.append("sphinx_immaterial.apidoc.json.domain")',
+                'json_schemas = ["schema.yml"]',
+            ]
+        ),
+        files={
+            "index.rst": """
+.. json:schema:: MySchema
+""",
+            "schema.yml": """$schema: http://json-schema.org/draft-07/schema#
+$id: MySchema
+type: array
+maxItems: 5
+""",
+        },
+    )
+    app.build()
+    assert not app._warning.getvalue()


### PR DESCRIPTION
Previously, this would incorrectly lead to an exception being thrown.