### PR TITLE
apidoc/python: Fix xrefs to type parameters

### DIFF
--- a/docs/type_param_demo.py
+++ b/docs/type_param_demo.py
@@ -70,7 +70,11 @@ class Map(Generic[K, V]):
     def get(self, key: K, default: T) -> Union[V, T]: ...
 
     def get(self, key: K, default=None):
-        """Return the mapped value, or the specified default."""
+        """Return the mapped value, or the specified default.
+
+        :param key: Key to retrieve.
+        :param default: Default value to return if key is not present.
+        """
         ...
 
     def __len__(self) -> int:

--- a/tests/python_apigen_test_modules/type_params.py
+++ b/tests/python_apigen_test_modules/type_params.py
@@ -1,0 +1,29 @@
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def foo(x: T) -> T:
+    """Foo function.
+
+    :param x: Something or other.
+    """
+    return x
+
+
+def bar(x: T) -> T:
+    return x
+
+
+class C:
+    def get(self, x: T, y: T) -> T:
+        """Get function.
+
+        :param x: Something or other.
+        :param y: Another param.
+        :type y: T
+        """
+        return x
+
+
+__all__ = ["foo", "bar", "C"]


### PR DESCRIPTION
Previously, if a function introduced a type parameter, any references to that type parameter in the signature itself were correctly resolved. However, when documenting function parameters, the type from the signature is duplicated next to the parameter name, and any references to type parameters in these duplicated types were not correctly resolved.

This commit fixes that issue by applying the same resolution logic to the duplicated types.