### PR TITLE
Various fixes to C++ domain and format_signatures

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -566,7 +566,8 @@ def _parse_confval_signature(
     if registry_option is None:
         logger.error("Invalid config option: %r", signature, location=node)
     else:
-        default, rebuild, types = registry_option
+        default = registry_option.default
+        types = registry_option.valid_types
         if isinstance(types, sphinx.config.ENUM):
             types = (typing.Literal[tuple(types.candidates)],)
         if isinstance(types, type):

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,7 @@ SUPPORTED_PY_VER = list(f"3.{x}" for x in range(9, 13))
 def ruff_format(session: nox.Session):
     """Checks formatting with ruff"""
     session.install("-r", "requirements/dev-ruff.txt")
-    session.run("ruff", "format")
+    session.run("ruff", "format", "--diff")
 
 
 @nox.session

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -1006,10 +1006,11 @@ TEMPLATE_PARAMETER_KIND_TO_JSON_KIND = {
 def _clang_template_parameter_to_json(config: Config, decl: Cursor):
     param_decl_str = get_extent_spelling(decl.translation_unit, decl.extent)
     param = _parse_template_parameter(param_decl_str)
+    spelling = decl.spelling
     if param is None:
         return {
             "declaration": param_decl_str,
-            "name": decl.spelling,
+            "name": spelling,
             "kind": TEMPLATE_PARAMETER_KIND_TO_JSON_KIND[decl.kind],
             # Heuristic to determine if it is a pack.
             "pack": "..." in param_decl_str,
@@ -1508,9 +1509,11 @@ def _sphinx_ast_template_parameter_to_json(
     else:
         kind = "non_type"
 
+    identifier = param.get_identifier()
+
     return {
         "declaration": _substitute_internal_type_names(config, str(param)),
-        "name": str(param.get_identifier()),
+        "name": str(identifier) if identifier else "",
         "kind": cast(TemplateParameterKind, kind),
         "pack": param.isPack,  # type: ignore[attr-defined]
     }

--- a/sphinx_immaterial/apidoc/cpp/apigen.py
+++ b/sphinx_immaterial/apidoc/cpp/apigen.py
@@ -185,7 +185,7 @@ def _get_cpp_api_data(
 
 def _transform_doc_comment(
     env: sphinx.environment.BuildEnvironment,
-    doc: api_parser.JsonDocComment,
+    doc: Optional[api_parser.JsonDocComment],
     summary: bool,
 ) -> Optional[docutils.statemachine.StringList]:
     if not doc:
@@ -651,7 +651,6 @@ def _add_enumerators(
         )
         anchor = f"e-{name}"
         child_doc = child["doc"]
-        assert child_doc is not None
         sphinx_utils.append_directive_to_stringlist(
             out,
             "cpp:enumerator",

--- a/sphinx_immaterial/apidoc/cpp/cpp_resolve_c_xrefs.py
+++ b/sphinx_immaterial/apidoc/cpp/cpp_resolve_c_xrefs.py
@@ -72,6 +72,13 @@ def _monkey_patch_cpp_resolve_c_xrefs():
         if refnode is not None:
             return refnode, objtype
 
+        if typ == "any":
+            # Don't forward to C domain for :any: xrefs, since it leads to an
+            # error determining the role type in CPPDomain.resolve_any_xref, and
+            # the C domain will have an opportunity to resolve this reference
+            # anyway.
+            return refnode, objtype
+
         macro_pattern = getattr(env.app, C_MACRO_PATTERN_ATTR, None)
 
         if (macro_pattern is not None and macro_pattern.fullmatch(target)) or (

--- a/sphinx_immaterial/apidoc/cpp/external_cpp_references.py
+++ b/sphinx_immaterial/apidoc/cpp/external_cpp_references.py
@@ -123,13 +123,14 @@ def _missing_reference(
     return newnode
 
 
+_CPPREFERENCE_APP_KEY = "_sphinx_immaterial_cppreference_objects"
+
+
 def get_mappings(app: sphinx.application.Sphinx) -> Dict[str, ObjectInfo]:
-    env = app.env
-    assert env is not None
-    cpp_objects = getattr(env, "cppreference_objects", None)
+    cpp_objects = getattr(app, _CPPREFERENCE_APP_KEY, None)
     if cpp_objects is None:
         cpp_objects = {}
-        setattr(env, "cppreference_objects", cpp_objects)
+        setattr(app, _CPPREFERENCE_APP_KEY, cpp_objects)
         return cpp_objects
     return cpp_objects
 

--- a/sphinx_immaterial/apidoc/format_signatures.py
+++ b/sphinx_immaterial/apidoc/format_signatures.py
@@ -584,10 +584,10 @@ _SIG_TRANSFORM_FUNCS: dict[
 }
 
 if sphinx.version_info >= (7, 3):
-    _SIG_TRANSFORM_FUNCS[
-        sphinx.addnodes.desc_type_parameter_list
-    ] = lambda ignored, node: _sig_transform_desc_parameter_list(
-        ignored, node, "[", "]"
+    _SIG_TRANSFORM_FUNCS[sphinx.addnodes.desc_type_parameter_list] = (
+        lambda ignored, node: _sig_transform_desc_parameter_list(
+            ignored, node, "[", "]"
+        )
     )
     _SIG_TRANSFORM_FUNCS[sphinx.addnodes.desc_type_parameter] = _sig_transform_parameter
 

--- a/sphinx_immaterial/apidoc/format_signatures.py
+++ b/sphinx_immaterial/apidoc/format_signatures.py
@@ -208,7 +208,7 @@ class FormatApplier:
         )
         self.adjusted_nodes.extend(new_adjusted_nodes)
         for adjusted_node in new_adjusted_nodes:
-            for text_node in adjusted_node.traverse(condition=docutils.nodes.Text):
+            for text_node in adjusted_node.findall(condition=docutils.nodes.Text):
                 orig_text = text_node.astext()
                 text = orig_text
                 parent = text_node.parent
@@ -245,7 +245,7 @@ class FormatApplier:
             list
         )
         for tag, i1, i2, j1, j2 in difflib.SequenceMatcher(
-            None,
+            " \t\n".__contains__,
             formatted_input,
             formatted_output,
             autojunk=False,

--- a/sphinx_immaterial/apidoc/python/type_annotation_transforms.py
+++ b/sphinx_immaterial/apidoc/python/type_annotation_transforms.py
@@ -218,7 +218,7 @@ def _monkey_patch_python_domain_to_transform_type_annotations():
         orig_parse_annotation = sphinx.domains.python._parse_annotation
 
     def _parse_annotation(annotation: str, env: sphinx.environment.BuildEnvironment):
-        transformer_config = getattr(env, _CONFIG_ATTR, None)
+        transformer_config = getattr(env.app, _CONFIG_ATTR, None)
         if transformer_config is None or not transformer_config.transform:
             return orig_parse_annotation(annotation, env)
 
@@ -298,7 +298,7 @@ def _builder_inited(app: sphinx.application.Sphinx):
         )
 
     setattr(
-        app.env,
+        app,
         _CONFIG_ATTR,
         TypeTransformConfig(
             transform=bool(
@@ -360,7 +360,7 @@ def _monkey_patch_python_domain_to_transform_xref_titles():
             and len(node.children) == 1
             and node.children[0].astext() == target
         ):
-            transformer_config = getattr(env, _CONFIG_ATTR, None)
+            transformer_config = getattr(env.app, _CONFIG_ATTR, None)
             if transformer_config is not None:
                 strip_modules_from_xrefs_pattern = (
                     transformer_config.strip_modules_from_xrefs_pattern

--- a/sphinx_immaterial/search_adapt.py
+++ b/sphinx_immaterial/search_adapt.py
@@ -191,7 +191,7 @@ class IndexBuilder(sphinx.search.IndexBuilder):
                 filenames.append(url)
             else:
                 docnames.append(docname)
-                filenames.append(self.env.doc2path(docname, False))
+                filenames.append(str(self.env.doc2path(docname, False)))
         frozen["docnames"] = docnames
         frozen["filenames"] = filenames
         new_data = format.dumps(frozen)

--- a/tests/cpp_api_parser_test.py
+++ b/tests/cpp_api_parser_test.py
@@ -222,3 +222,25 @@ int function(T arg1, T &arg2, T &arg3);
         ]
     )
     assert expected == doc_str
+
+
+def test_unnamed_template_parameter():
+    config = api_parser.Config(
+        input_path="a.cpp",
+        compiler_flags=["-std=c++17", "-x", "c++"],
+        input_content=rb"""
+/// Tests something.
+///
+/// \ingroup Array
+template <typename = void>
+constexpr inline bool IsArray = false;
+""",
+    )
+
+    output = api_parser.generate_output(config)
+    entities = output.get("entities", {})
+    assert len(entities) == 1
+    entity = list(entities.values())[0]
+    tparams = entity["template_parameters"]
+    assert tparams is not None
+    assert tparams[0]["name"] == ""

--- a/tests/cpp_apigen_test.py
+++ b/tests/cpp_apigen_test.py
@@ -1,0 +1,38 @@
+"""Tests cpp/apigen."""
+
+
+def test_unnamed_template_parameter(immaterial_make_app):
+    app = immaterial_make_app(
+        extra_conf="""
+extensions.append("sphinx_immaterial.apidoc.cpp.apigen")
+""",
+        confoverrides=dict(
+            nitpicky=True,
+            cpp_apigen_configs=[
+                dict(
+                    document_prefix="cpp_apigen_generated/",
+                    api_parser_config=dict(
+                        input_content=r"""
+/// Tests if something is an array.
+///
+/// \ingroup Array
+template <typename T, typename = void>
+constexpr inline bool IsArray = false;
+""",
+                        compiler_flags=["-std=c++17", "-x", "c++"],
+                        verbose=True,
+                    ),
+                ),
+            ],
+        ),
+        files={
+            "index.rst": """
+.. cpp-apigen-group:: Array
+
+"""
+        },
+    )
+
+    app.build()
+
+    assert not app._warning.getvalue()

--- a/tests/cpp_xref_c_domain_test.py
+++ b/tests/cpp_xref_c_domain_test.py
@@ -1,0 +1,21 @@
+"""Tests that references to C objects can be resolved via cpp domain xrefs."""
+
+
+def test_cpp_xref_resolves_to_c_obj(immaterial_make_app):
+    app = immaterial_make_app(
+        files={
+            "index.rst": """
+.. c:macro:: FOO
+
+   Some macro.
+
+:cpp:expr:`FOO`
+
+:any:`FOO`
+"""
+        },
+    )
+
+    app.build()
+
+    assert not app._warning.getvalue()


### PR DESCRIPTION
- Make C++ doc comment parsing more robust and don't rely on raw_comment from clang
- Fix handling of whitespace in format_signatures
- Remove unnecessary data from env to improve parallel build efficiency
- Fix building with Sphinx 8.0.2
- Fix C++ apigen handling of unnamed template parameters
- Fix `:any:` xrefs to C macros
- Support undocumented enumerators