### PR TITLE
python/apigen: Fix support for pybind11 overloaded functions

### DIFF
--- a/tests/issue_134/sphinx-immaterial-pybind11-issue-134/sphinx_immaterial_pybind11_issue_134.cpp
+++ b/tests/issue_134/sphinx-immaterial-pybind11-issue-134/sphinx_immaterial_pybind11_issue_134.cpp
@@ -30,6 +30,24 @@ PYBIND11_MODULE(sphinx_immaterial_pybind11_issue_134, m) {
                               [](const Example& self) -> int { return 42; });
   }
 
+  cls.def(
+      "foo", [](Example& self, int x) { return 1; }, R"docstr(
+Int overload.
+
+Overload:
+  int
+)docstr");
+
+  cls.def(
+      "foo", [](Example& self, bool x) { return 1; }, R"docstr(
+Bool overload.
+
+Overload:
+  bool
+)docstr");
+
+  cls.attr("bar") = cls.attr("foo");
+
   cls.def_readonly("is_set_by_init", &Example::is_set_by_init, R"docstr(
             This read-only ``bool`` attribute is set by the constructor.
         )docstr");

--- a/tests/snapshots/python_apigen_test/test_pybind11_overloaded_function/Example.bar_bool.json
+++ b/tests/snapshots/python_apigen_test/test_pybind11_overloaded_function/Example.bar_bool.json
@@ -1,0 +1,7 @@
+{
+  "signatures": [
+    "(self: sphinx_immaterial_pybind11_issue_134.Example, arg0: bool) -> int"
+  ],
+  "primary_entity": false,
+  "siblings": null
+}

--- a/tests/snapshots/python_apigen_test/test_pybind11_overloaded_function/Example.bar_int.json
+++ b/tests/snapshots/python_apigen_test/test_pybind11_overloaded_function/Example.bar_int.json
@@ -1,0 +1,7 @@
+{
+  "signatures": [
+    "(self: sphinx_immaterial_pybind11_issue_134.Example, arg0: int) -> int"
+  ],
+  "primary_entity": false,
+  "siblings": null
+}

--- a/tests/snapshots/python_apigen_test/test_pybind11_overloaded_function/Example.foo_bool.json
+++ b/tests/snapshots/python_apigen_test/test_pybind11_overloaded_function/Example.foo_bool.json
@@ -1,0 +1,9 @@
+{
+  "signatures": [
+    "(self: sphinx_immaterial_pybind11_issue_134.Example, arg0: bool) -> int"
+  ],
+  "primary_entity": true,
+  "siblings": {
+    "sphinx_immaterial_pybind11_issue_134.Example.bar(bool)": true
+  }
+}

--- a/tests/snapshots/python_apigen_test/test_pybind11_overloaded_function/Example.foo_int.json
+++ b/tests/snapshots/python_apigen_test/test_pybind11_overloaded_function/Example.foo_int.json
@@ -1,0 +1,9 @@
+{
+  "signatures": [
+    "(self: sphinx_immaterial_pybind11_issue_134.Example, arg0: int) -> int"
+  ],
+  "primary_entity": true,
+  "siblings": {
+    "sphinx_immaterial_pybind11_issue_134.Example.bar(int)": true
+  }
+}


### PR DESCRIPTION
This was accidentally broken by
https://github.com/jbms/sphinx-immaterial/pull/357.