### PR TITLE
Fix C/C++ domain support for :node-id: and :symbol-ids:

### DIFF
--- a/sphinx_immaterial/apidoc/cpp/symbol_ids.py
+++ b/sphinx_immaterial/apidoc/cpp/symbol_ids.py
@@ -1,15 +1,29 @@
 """Adds support for :noindex:, :symbol-ids:, and :node-id: options."""
 
 import json
-from typing import Optional, Union, Type, List
+import re
+from typing import Optional, Union, Type, List, Tuple
 
 import docutils.parsers.rst.directives
 import sphinx.addnodes
 import sphinx.domains.c
 import sphinx.domains.cpp
+from sphinx.domains.c import CDomain
+from sphinx.domains.cpp import CPPDomain
+
+from . import last_resolved_symbol
 
 AST_ID_OVERRIDE_ATTR = "_sphinx_immaterial_id"
 ANCHOR_ATTR = "sphinx_immaterial_anchor"
+
+PARAMETER_OBJECT_TYPES = (
+    "functionParam",
+    "macroParam",
+    "templateParam",
+    "templateTypeParam",
+    "templateTemplateParam",
+    "templateNonTypeParam",
+)
 
 
 def _monkey_patch_override_ast_id(
@@ -176,6 +190,63 @@ def _monkey_patch_cpp_noindex_option(
     object_class.run = run  # type: ignore[assignment]
 
 
+def _monkey_patch_to_override_symbol_anchor(
+    domain_class: Union[
+        Type[sphinx.domains.cpp.CPPDomain], Type[sphinx.domains.c.CDomain]
+    ],
+):
+    """Patch C/C++ resolve_xref to allow overriding the anchor id."""
+    orig_resolve_xref_inner = domain_class._resolve_xref_inner
+
+    def _resolve_xref_inner(
+        self: Union[CDomain, CPPDomain],
+        env: sphinx.environment.BuildEnvironment,
+        fromdocname: str,
+        builder: sphinx.builders.Builder,
+        typ: str,
+        target: str,
+        node: sphinx.addnodes.pending_xref,
+        contnode: docutils.nodes.Element,
+    ) -> Tuple[Optional[docutils.nodes.Element], Optional[str]]:
+        refnode, objtype = orig_resolve_xref_inner(
+            self,  # type: ignore
+            env,
+            fromdocname,
+            builder,
+            typ,
+            target,
+            node,
+            contnode,
+        )
+        if refnode is None:
+            return refnode, objtype
+
+        assert objtype is not None
+
+        last_symbol = last_resolved_symbol.get_symbol()
+
+        if (
+            objtype in PARAMETER_OBJECT_TYPES
+            and getattr(last_symbol.declaration, AST_ID_OVERRIDE_ATTR, None) is None
+        ):
+            # This is a parameter without an associated `:param:` entry.  It
+            # should just be linked to the parent symbol.
+            anchor = get_symbol_anchor(last_symbol.parent)
+        else:
+            anchor = get_symbol_anchor(last_symbol)
+
+        if "refid" in refnode:
+            refnode["refid"] = anchor
+        else:
+            new_refurl = re.sub("#.*", "", refnode["refuri"])
+            if anchor:
+                new_refurl += f"#{anchor}"
+            refnode["refurl"] = new_refurl
+        return refnode, objtype
+
+    domain_class._resolve_xref_inner = _resolve_xref_inner  # type: ignore
+
+
 _monkey_patch_override_ast_id(sphinx.domains.c.ASTDeclaration)
 _monkey_patch_override_ast_id(sphinx.domains.cpp.ASTDeclaration)
 _monkey_patch_cpp_noindex_option(
@@ -190,3 +261,5 @@ _monkey_patch_cpp_noindex_option(
     env_parent_symbol_key="c:parent_symbol",
     duplicate_symbol_error=sphinx.domains.c._DuplicateSymbolError,
 )
+_monkey_patch_to_override_symbol_anchor(domain_class=sphinx.domains.cpp.CPPDomain)
+_monkey_patch_to_override_symbol_anchor(domain_class=sphinx.domains.c.CDomain)

--- a/sphinx_immaterial/apidoc/cpp/synopses.py
+++ b/sphinx_immaterial/apidoc/cpp/synopses.py
@@ -1,3 +1,5 @@
+"""Adds support for synopses to C/C++ domains."""
+
 from typing import Union, Type, Optional, Tuple, Iterator
 
 import docutils.nodes

--- a/tests/cpp_domain_test.py
+++ b/tests/cpp_domain_test.py
@@ -1,0 +1,101 @@
+"""Tests C++ domain functionality added by this theme."""
+
+import json
+
+import docutils.nodes
+import pytest
+
+pytest_plugins = ("sphinx.testing.fixtures",)
+
+
+def snapshot_references(app, snapshot):
+    doc = app.env.get_and_resolve_doctree("index", app.builder)
+
+    nodes = list(doc.findall(condition=docutils.nodes.reference))
+
+    node_data = [
+        {
+            "text": node.astext(),
+            **{
+                attr: node.get(attr)
+                for attr in ["refid", "refurl", "reftitle"]
+                if attr in node
+            },
+        }
+        for node in nodes
+    ]
+
+    snapshot.assert_match("\n".join(json.dumps(n) for n in node_data), "references.txt")
+
+
+@pytest.mark.parametrize("node_id", [None, "", "abc"])
+def test_parameter_objects(immaterial_make_app, snapshot, node_id: str):
+    """Tests that parameter objects take into account the `node-id` option."""
+
+    attrs = []
+    if node_id is not None:
+        attrs.append(f":node-id: {node_id}")
+    attrs_text = "\n".join(attrs)
+
+    app = immaterial_make_app(
+        files={
+            "index.rst": f"""
+
+.. cpp:function:: void foo(int bar, int baz, int undocumented);
+   {attrs_text}
+
+   Test function.
+
+   :param bar: Bar parameter.
+   :param baz: Baz parameter.
+""",
+        },
+    )
+
+    app.build()
+
+    snapshot_references(app, snapshot)
+
+
+def test_template_parameter_objects(immaterial_make_app, snapshot):
+    """Tests that xrefs to template parameters include template parameter kind
+    in tooltip text."""
+    app = immaterial_make_app(
+        files={
+            "index.rst": """
+
+.. cpp:function:: template <typename T, int N, template<typename> class U>\
+                  void foo();
+
+   Test function.
+
+   :tparam T: T parameter.
+   :tparam N: N parameter.
+""",
+        },
+    )
+
+    app.build()
+
+    snapshot_references(app, snapshot)
+
+
+def test_macro_parameter_objects(immaterial_make_app, snapshot):
+    """Tests that macro parameters work correctly."""
+    app = immaterial_make_app(
+        files={
+            "index.rst": """
+
+.. c:macro:: FOO(a, b, c)
+
+   Test macro.
+
+   :param a: A parameter.
+   :param b: B parameter.
+""",
+        },
+    )
+
+    app.build()
+
+    snapshot_references(app, snapshot)

--- a/tests/snapshots/cpp_domain_test/test_macro_parameter_objects/references.txt
+++ b/tests/snapshots/cpp_domain_test/test_macro_parameter_objects/references.txt
@@ -1,0 +1,3 @@
+{"text": "a", "refid": "c.FOO-p-a", "reftitle": "a (C macro parameter) \u2014 A parameter."}
+{"text": "b", "refid": "c.FOO-p-b", "reftitle": "b (C macro parameter) \u2014 B parameter."}
+{"text": "c", "refid": "c.FOO", "reftitle": "c (C macro parameter)"}

--- a/tests/snapshots/cpp_domain_test/test_parameter_objects/None/references.txt
+++ b/tests/snapshots/cpp_domain_test/test_parameter_objects/None/references.txt
@@ -1,0 +1,3 @@
+{"text": "bar", "refid": "_CPPv43fooiii-p-bar", "reftitle": "foo::bar (C++ function parameter) \u2014 Bar parameter."}
+{"text": "baz", "refid": "_CPPv43fooiii-p-baz", "reftitle": "foo::baz (C++ function parameter) \u2014 Baz parameter."}
+{"text": "undocumented", "refid": "_CPPv43fooiii", "reftitle": "foo::undocumented (C++ function parameter)"}

--- a/tests/snapshots/cpp_domain_test/test_parameter_objects/abc/references.txt
+++ b/tests/snapshots/cpp_domain_test/test_parameter_objects/abc/references.txt
@@ -1,0 +1,3 @@
+{"text": "bar", "refid": "abc-p-bar", "reftitle": "foo::bar (C++ function parameter) \u2014 Bar parameter."}
+{"text": "baz", "refid": "abc-p-baz", "reftitle": "foo::baz (C++ function parameter) \u2014 Baz parameter."}
+{"text": "undocumented", "refid": "abc", "reftitle": "foo::undocumented (C++ function parameter)"}

--- a/tests/snapshots/cpp_domain_test/test_parameter_objects/empty/references.txt
+++ b/tests/snapshots/cpp_domain_test/test_parameter_objects/empty/references.txt
@@ -1,0 +1,3 @@
+{"text": "bar", "refid": "p-bar", "reftitle": "foo::bar (C++ function parameter) \u2014 Bar parameter."}
+{"text": "baz", "refid": "p-baz", "reftitle": "foo::baz (C++ function parameter) \u2014 Baz parameter."}
+{"text": "undocumented", "refid": "", "reftitle": "foo::undocumented (C++ function parameter)"}

--- a/tests/snapshots/cpp_domain_test/test_template_parameter_objects/references.txt
+++ b/tests/snapshots/cpp_domain_test/test_template_parameter_objects/references.txt
@@ -1,0 +1,3 @@
+{"text": "T", "refid": "_CPPv4I0_iI0E0E3foovv-p-T", "reftitle": "foo::T (C++ type template parameter) \u2014 T parameter."}
+{"text": "N", "refid": "_CPPv4I0_iI0E0E3foovv-p-N", "reftitle": "foo::N (C++ non-type template parameter) \u2014 N parameter."}
+{"text": "U", "refid": "_CPPv4I0_iI0E0E3foovv", "reftitle": "foo::U (C++ template template parameter)"}


### PR DESCRIPTION
Previously, these were not properly taken into account by parameter objects.