### PR TITLE
Sphin 8.1.0 and MathDomain import

### DIFF
--- a/sphinx_immaterial/local_mathjax.py
+++ b/sphinx_immaterial/local_mathjax.py
@@ -4,7 +4,8 @@ from typing import Dict, Any, cast
 from sphinx.application import Sphinx
 from sphinx.config import Config
 from sphinx.errors import ExtensionError
-from sphinx.ext.mathjax import MATHJAX_URL, MathDomain
+from sphinx.domains.math import MathDomain
+from sphinx.ext.mathjax import MATHJAX_URL
 from sphinx.environment import BuildEnvironment
 
 


### PR DESCRIPTION
Sphinx 8.1.0 removed import of MathDomain into sphinx.ext.mathjax that resulted in sphinx-immaterial crashing with ImportError. Replaced with import from actual package that defines MathDomain.

Sphinx seems to be moving away from using get_domain to get domain instances, however it is available only from versions >=8.1.0, so I left get_domain call as it is currently.

Verified to work with Sphinx 8.0.2 and 8.1.0 but I'm not using mathjax domain.