### PR TITLE
fix: support for sphinx v8.1.0

### DIFF
--- a/sphinx_immaterial/apidoc/generic_synopses.py
+++ b/sphinx_immaterial/apidoc/generic_synopses.py
@@ -50,7 +50,7 @@ def _monkey_patch_generic_object_to_support_synopses():
 
     orig_merge_domaindata = StandardDomain.merge_domaindata
 
-    def merge_domaindata(self, docnames: List[str], otherdata: dict) -> None:
+    def merge_domaindata(self, docnames, otherdata: dict) -> None:
         orig_merge_domaindata(self, docnames, otherdata)
         self.data["synopses"].update(otherdata["synopses"])
 

--- a/sphinx_immaterial/apidoc/json/domain.py
+++ b/sphinx_immaterial/apidoc/json/domain.py
@@ -1150,7 +1150,7 @@ class JsonSchemaDomain(sphinx.domains.Domain):
                 else OBJECT_PRIORITY_UNIMPORTANT,
             )
 
-    def merge_domaindata(self, docnames: List[str], otherdata: Dict) -> None:
+    def merge_domaindata(self, docnames, otherdata: Dict) -> None:
         self.schemas.update(otherdata["schemas"])
 
     def _find_schema(

--- a/sphinx_immaterial/apidoc/python/synopses.py
+++ b/sphinx_immaterial/apidoc/python/synopses.py
@@ -130,7 +130,7 @@ def _monkey_patch_python_domain_to_support_synopses():
 
     orig_merge_domaindata = PythonDomain.merge_domaindata
 
-    def merge_domaindata(self, docnames: List[str], otherdata: dict) -> None:
+    def merge_domaindata(self, docnames, otherdata: dict) -> None:
         orig_merge_domaindata(self, docnames, otherdata)
         self.data["synopses"].update(otherdata["synopses"])
 

--- a/sphinx_immaterial/local_mathjax.py
+++ b/sphinx_immaterial/local_mathjax.py
@@ -4,7 +4,8 @@ from typing import Dict, Any, cast
 from sphinx.application import Sphinx
 from sphinx.config import Config
 from sphinx.errors import ExtensionError
-from sphinx.ext.mathjax import MATHJAX_URL, MathDomain
+from sphinx.domains.math import MathDomain
+from sphinx.ext.mathjax import MATHJAX_URL
 from sphinx.environment import BuildEnvironment
 
 


### PR DESCRIPTION
Originally raised in #392 about Math domain. This adds type inference for monkey patched domain merge functions.

Offending commits in sphinx v8.1.0:
- https://github.com/sphinx-doc/sphinx/commit/d1c23a08a9d8b1fc77ad8c1a368c17b18e8fdc85
- https://github.com/sphinx-doc/sphinx/commit/76110c3ea05e4eef02bc1689c4b9253aca743392