### PR TITLE
Fix C++ apigen page naming for variable template specializations

### DIFF
--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -112,7 +112,7 @@ TEMPLATE_PARAMETER_ENABLE_IF_NON_TYPE_PATTERN = re.compile(
 )
 
 SPECIAL_GROUP_COMMAND_PATTERN = re.compile(
-    r"^(?:\\|@)(ingroup|relates|membergroup|id)\s+(.+[^\s])\s*$", re.MULTILINE
+    r"^(?:\\|@)(ingroup|relates|membergroup|id)\s+(.*[^\s])\s*$", re.MULTILINE
 )
 
 
@@ -2206,7 +2206,9 @@ def _format_template_arguments(entity: CppApiEntity) -> str:
 
 def _get_entity_base_page_name_component(entity: CppApiEntity) -> str:
     base_name = entity["name"]
-    if entity["kind"] == "class" and entity.get("specializes"):
+    if (entity["kind"] == "class" or entity["kind"] == "var") and entity.get(
+        "specializes"
+    ):
         # Strip any template arguments
         base_name = re.sub("([^<]*).*", r"\1", base_name)
     elif entity["kind"] == "conversion_function":


### PR DESCRIPTION
Previously, the page names for variable template specializations incorrectly included the template arguments within angle brackets, unlike class template specializations where such arguments were stripped.

With this commit, template arguments are stripped and the entities are distinguished based on the user-specified `id`.