### PR TITLE
Fix search term match and highlight for Unicode chars

### DIFF
--- a/src/assets/javascripts/sphinx_search.ts
+++ b/src/assets/javascripts/sphinx_search.ts
@@ -724,7 +724,7 @@ export async function getResults(query: string): Promise<SearchResultStream> {
     // The search term made be made up of multiple "words" separated
     // by special characters like [-._].  Split them up and treat each
     // as a separate search term.
-    for (const wordMatch of lowerTerm.matchAll(/\w+/g)) {
+    for (const wordMatch of lowerTerm.matchAll(/\p{L}+/gu)) {
       const subTerm = wordMatch[0]
       if (stopwords.indexOf(subTerm) !== -1) {
         // skip this "word"
@@ -794,8 +794,8 @@ export async function getResults(query: string): Promise<SearchResultStream> {
   }
 
   const pattern = new RegExp(
-    `\\b(?:${  hlterms.map(escapeRegExp).join("|")  })`,
-    "img"
+    `(?:${  hlterms.map(escapeRegExp).join("|")  })`,
+    "imgu"
   )
   const highlight = (s: unknown) => {
     return `<mark data-md-highlight>${s}</mark>`
@@ -803,7 +803,7 @@ export async function getResults(query: string): Promise<SearchResultStream> {
   const highlightTerms = (text: string) => {
     return escapeHTML(text)
       .replace(pattern, highlight)
-      .replace(/<\/mark>(\s+)<mark[^>]*>/gim, "$1")
+      .replace(/<\/mark>(\s+)<mark[^>]*>/gimu, "$1")
   }
 
   return {


### PR DESCRIPTION
A regular expression `/\w+/g` was added in PR #307, which broke the search for non-english words.

I changed it to `/\p{L}+/gu` to add support for all Unicode characters and removed redundant word boundary (`\b`) in highlight regex.

Fixes #399 