### PR TITLE
Fix navigation.tabs for non-leaf pages

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -56,7 +56,7 @@
     "custom-property-empty-line-before": null,
     "custom-property-pattern": null,
     "declaration-colon-space-after": null,
-    "declaration-no-important": true,
+    "declaration-no-important": null,
     "declaration-block-single-line-max-declarations": 0,
     "function-calc-no-unspaced-operator": null,
     "function-no-unknown": null,

--- a/src/assets/stylesheets/main/layout/_nav.scss
+++ b/src/assets/stylesheets/main/layout/_nav.scss
@@ -453,7 +453,7 @@
     // sphinx-immaterial: hide nested nav items of current page, since
     // they are redundant with integrated toc.
     &__current-nested {
-      display: none;
+      display: none !important;
     }
 
     // Show link to table of contents
@@ -514,7 +514,7 @@
 
     // sphinx-immaterial: hide integreated toc, since it is redundant with any nested items.
     &__current-toc {
-      display: none;
+      display: none !important;
     }
 
     // Navigation title

--- a/tests/snapshots/format_signatures_test/test_format_signatures/py_function_astext.txt
+++ b/tests/snapshots/format_signatures_test/test_format_signatures/py_function_astext.txt
@@ -2,7 +2,7 @@ some_module.method_name(
     some_parameter_with_a_long_name: collections.abc.MutableMapping[
         tuple[str, float, numbers.Real],
         dict[int, tuple[list[frozenset[int]]]],
-    ]
+    ],
 ) -> collections.abc.MutableMapping[
     tuple[str, float, numbers.Real],
     dict[int, tuple[list[frozenset[int]]]],


### PR DESCRIPTION
Previously, when using navigation.tabs on non-leaf pages, the integrated TOC used for "layered" (mobile) navigation would incorrectly display as well. The fix in 87d87f900901ec56aff1df09572f68497bafcf31 was was not sufficient due to a CSS precedence issue, which is now corrected by using `!important`.