### PR TITLE
Fix pending_xref issue with format_signatures

### DIFF
--- a/tests/snapshots/format_signatures_test/test_format_signatures/py_function2_astext.txt
+++ b/tests/snapshots/format_signatures_test/test_format_signatures/py_function2_astext.txt
@@ -1,0 +1,8 @@
+create(
+    chunk_key_encoding: (
+        zarr.core.chunk_key_encodings.ChunkKeyEncoding
+        | tuple["default", "." | "/"]
+        | tuple["v2", "." | "/"]
+        | None
+    ) = None,
+) -> Array


### PR DESCRIPTION
Previously, the format_signatures extension could result in pending_xref nodes with more than one child.  Sphinx assumes that pending_xref nodes only contain a single child, and if the reference fails to resolve, will discard all but the first child.

With this change, if there is more than one child to be added to a pending_xref node, they are wrapped in an `inline` node.