### PR TITLE
Ignore leading `*` characters in Python parameter names

### DIFF
--- a/sphinx_immaterial/apidoc/python/parameter_objects.py
+++ b/sphinx_immaterial/apidoc/python/parameter_objects.py
@@ -61,7 +61,7 @@ def _monkey_patch_python_doc_fields():
         def handle_item(fieldarg: str, content: Any) -> docutils.nodes.Node:
             node = docutils.nodes.definition_list_item()
             term_node = docutils.nodes.term()
-            term_node["paramname"] = fieldarg
+            term_node["paramname"] = fieldarg.lstrip("*")
             term_node += sphinx.addnodes.desc_name(fieldarg, fieldarg)
             fieldtype = types.pop(fieldarg, None)
             if fieldtype:

--- a/tests/python_parameter_cross_link_test.py
+++ b/tests/python_parameter_cross_link_test.py
@@ -1,0 +1,19 @@
+def test_python_parameter_cross_link(immaterial_make_app, snapshot):
+    app = immaterial_make_app(
+        files={
+            "index.rst": r"""
+.. py:function:: foo(x: int, *args: list[int], **kwargs: dict[str, int]) -> int
+
+   Description goes here.
+
+   :param x: X parameter.
+   :param \*args: Args parameter.
+   :param \*\*kwargs: Kwargs parameter.
+
+"""
+        },
+    )
+
+    app.build()
+
+    assert not app._warning.getvalue()


### PR DESCRIPTION
Previously, Python parameters documented as `*args` or `**kwargs` (rather than just `args` or `kwargs`) did not get cross-linked properly.

Now, any leading `*` characters are ignored for the purpose of matching.