### PR TITLE
Support maximum_signature_line_length Sphinx option

### DIFF
--- a/docs/apidoc/format_signatures.rst
+++ b/docs/apidoc/format_signatures.rst
@@ -1,23 +1,37 @@
 Formatting signatures
 =====================
 
-This theme provides two alternative ways to automatically format/indent API
+This theme supports three alternative ways to automatically format/indent API
 documentation signatures.
 
-CSS-based function parameter wrapping
--------------------------------------
+Basic function parameter wrapping
+---------------------------------
 
-There is a CSS-based formatting rule that can be enabled for long function
-signatures that displays each function parameter on a separate line.  This is
-enabled by default, and works fairly well for Python signatures.
+As of Sphinx 7.1, the :confval:`maximum_signature_line_length` option (and its
+domain-specific variants) may be used to enable basic automatic parameter
+wrapping. The recommended limit for this theme is :python:`68`.
+
+.. warning::
+
+   Even with the recommended limit of :python:`68`, signature lines may be too
+   long and display poorly on very narrow browser viewports, such as mobile
+   phones in portrait mode.
+
+This theme also supports a CSS-based formatting rule that can be enabled for
+long function signatures that displays each function parameter on a separate
+line. This is enabled by default (when the
+:confval:`maximum_signature_line_length` option is not enabled), and works
+fairly well for Python signatures.
 
 It is controlled by the following `object description
 options<object-description-options>`:
 
 .. objconf:: wrap_signatures_with_css
 
-   Indicates whether CSS-based formatting is enabled.  Disabled automatically if
-   :objconf:`clang_format_style` is specified.
+   Indicates whether CSS-based formatting is enabled. Disabled automatically if
+   :objconf:`clang_format_style` or :objconf:`black_format_style` is specified.
+   Also disabled automatically if the global or domain-specific
+   :confval:`maximum_signature_line_length` option is enabled.
 
 .. objconf:: wrap_signatures_column_limit
 
@@ -49,6 +63,25 @@ following to :file:`conf.py`:
                       yet_another: bool = False, \
                       finally_another: str = "some long string goes here"\
                     ) -> Tuple[str, bool, float, bytes, int]
+
+.. note::
+
+   The :confval:`maximum_signature_line_length` and
+   :objconf:`wrap_signatures_with_css` options produce similar results.
+
+   The key differences are:
+
+   - :confval:`maximum_signature_line_length` wraps Python type parameters in a
+     more sophisticated way.
+
+   - :objconf:`wrap_signatures_with_css` properly accounts for
+     :confval:`python_type_aliases` and other related type annotation
+     transformations.
+
+   With either option, individual parameters that are too long to fit on a
+   single line will *not* be wrapped/indented properly. For more advanced
+   formatting, the `External code formatter integration`_ is recommended
+   instead.
 
 External code formatter integration
 -----------------------------------

--- a/sphinx_immaterial/apidoc/wrap_signatures.py
+++ b/sphinx_immaterial/apidoc/wrap_signatures.py
@@ -17,6 +17,15 @@ def _wrap_signature(node: sphinx.addnodes.desc_signature, limit: int):
         node["classes"].append("sig-wrap")
 
 
+def _get_maximum_signature_line_length_option(
+    app: sphinx.application.Sphinx, domain: str
+) -> int | None:
+    config = app.config
+    return getattr(config, f"{domain}_maximum_signature_line_length", None) or getattr(
+        config, "maximum_signature_line_length", None
+    )
+
+
 def _wrap_signatures(
     app: sphinx.application.Sphinx,
     domain: str,
@@ -31,6 +40,10 @@ def _wrap_signatures(
     if (
         not options["wrap_signatures_with_css"]
         or options.get("clang_format_style") is not None
+        or options.get("black_format_style") is not None
+        # Disable if the Sphinx `maximum_signature_length_length` option is
+        # enabled for this domain.
+        or _get_maximum_signature_line_length_option(app, domain)
     ):
         return
     signatures = content.parent[:-1]

--- a/src/templates/assets/stylesheets/main/_api.scss
+++ b/src/templates/assets/stylesheets/main/_api.scss
@@ -33,6 +33,15 @@ $objinfo-icon-size: 16px;
       color: $api-color-param-name;
     }
 
+    // These elements are added by Sphinx when the
+    // `maximum_signature_line_length` is specified. Override the margins
+    // specified in `_typeset.scss`.
+    dl,
+    dd {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+
     .sig-param a.reference .n:not(.desctype):hover {
       color: var(--md-accent-fg-color);
     }
@@ -161,7 +170,6 @@ $objinfo-icon-size: 16px;
 
   dl.api-field {
     > dt {
-
       // Display as table so that background is just the width of the
       // content.
       display: table;
@@ -227,7 +235,6 @@ $objinfo-icon-size: 16px;
 
 // Only use dark mode on screens
 @media screen {
-
   // Slate theme, i.e. dark mode
   [data-md-color-scheme="slate"] {
     --objinfo-icon-fg-alias: #{$clr-orange-300};


### PR DESCRIPTION
Previously, specifying the maximum_signature_line_length option resulted in excessive blank lines within signatures due to undesired CSS dl/dd margin rule applicability.

Additionally, the `wrap_signatures_with_css` option, enabled by default, added redundant spacing.

This commit fixes dl/dd margin rules, and also disables `wrap_signatures_with_css` automatically when
`maximum_signature_line_length` is enabled.

Fixes https://github.com/jbms/sphinx-immaterial/issues/419.