### PR TITLE
Fix alignment issue in format_signatures

### DIFF
--- a/tests/format_signatures_test.py
+++ b/tests/format_signatures_test.py
@@ -32,6 +32,7 @@ TEST_SIGNATURES = {
     "py_class_constructor_long": r"py:class:: zarr.abc.store.Store2(some_long_positional_parameter: collections.abc.MutableMapping[\
                                   tuple[str, float, numbers.Real], \
                                   dict[int, tuple[list[frozenset[int]]]]], *, read_only: bool = False)",
+    "py_function3": "py:method:: zarr.Array.from_dict(store_path: StorePath,data: dict[str, str | int | float | Mapping[str, str | int | float | Mapping[str, JSON] | Sequence[JSON] | None] | Sequence[str | int | float | Mapping[str, JSON] | Sequence[JSON] | None] | None])->Array",
 }
 
 
@@ -87,7 +88,6 @@ object_description_options = [
     app.add_post_transform(AfterFormatSignatures)
 
     app.build()
-
     assert not app._warning.getvalue()
 
     # Validate that the correct formatted result is preserved after references

--- a/tests/snapshots/format_signatures_test/test_format_signatures/py_function3_astext.txt
+++ b/tests/snapshots/format_signatures_test/test_format_signatures/py_function3_astext.txt
@@ -1,0 +1,27 @@
+zarr.Array.from_dict(
+    store_path: StorePath,
+    data: dict[
+        str,
+        str
+        | int
+        | float
+        | Mapping[
+            str,
+            str
+            | int
+            | float
+            | Mapping[str, JSON]
+            | collections.abc.Sequence[JSON]
+            | None,
+        ]
+        | collections.abc.Sequence[
+            str
+            | int
+            | float
+            | Mapping[str, JSON]
+            | collections.abc.Sequence[JSON]
+            | None
+        ]
+        | None,
+    ],
+) -> Array


### PR DESCRIPTION
Previously, format_signatures just called difflib.SequenceMatcher for alignment, which sometimes produced poor results, leading to broken pending_xref nodes.

This commit uses an improved algorithm that is faster and ensures alphanumeric characters are always perfectly aligned.

This commit also ensures that a failure to format is treated as a warning rather than error, and just skips formatting the individual signature that failed.