### PR TITLE
Fix parsing of frontmatter config in mermaid diagrams

### DIFF
--- a/sphinx_immaterial/mermaid_diagrams.py
+++ b/sphinx_immaterial/mermaid_diagrams.py
@@ -33,7 +33,7 @@ class MermaidDirective(SphinxDirective):
         self.assert_has_content()
         content = "\n".join(self.content)
         diagram = mermaid_node("", classes=["mermaid"], content=content)
-        diagram += nodes.literal("", content, format="html")
+        diagram += nodes.literal_block("", content, language="none", format="html")
         diagram_div = nodes.container(
             "",
             is_div=True,


### PR DESCRIPTION
Mermaid diagrams can be configured by a frontmatter block at the top of the diagram definition, e.g., for `classDiagram`:
```yaml
---
config:
    class:
        hideEmptyMembersBox: true
---
classDiagram
    class Duck
```
https://mermaid.js.org/syntax/classDiagram.html#members-box

It doesn't work in sphinx-immaterial at the moment because `docutils.nodes.literal` changes spaces to `&nbsp` (`&#160;`) characters when parsing word tokens for highlighting, and then [frontmatter parsing in mermaid](https://github.com/mermaid-js/mermaid/blob/7b2083926dbe3b6280f42376a0d4195b2c72fb8e/packages/mermaid/src/diagram-api/frontmatter.ts#L33-L38) breaks.

That's why I've decided to change it `docutils.nodes.literal_block` with disabled highlighting. That way, the code of a diagram is passed to mermaid.js as is.

Output before change:

```html
<div class="mermaid-diagram docutils">
<pre class="mermaid">
<code class="docutils literal notranslate"><span class="pre">---</span>
<span class="pre">config:</span>
&#160;&#160;&#160; <span class="pre">class:</span>
&#160;&#160;&#160;&#160;&#160;&#160;&#160; <span class="pre">hideEmptyMembersBox:</span> <span class="pre">true</span>
<span class="pre">---</span>
<span class="pre">classDiagram</span>
&#160;&#160;&#160; <span class="pre">class</span> <span class="pre">Duck</span></code></pre></div>
```
![image](https://github.com/user-attachments/assets/0537eb58-8c40-484f-8821-9f95216aa18a)


Output after change:
```html
<div class="mermaid-diagram docutils">
<pre class="mermaid">
<div class="highlight-none notranslate"><div class="highlight"><pre><span></span><code>---
config:
    class:
        hideEmptyMembersBox: true
---
classDiagram
    class Duck
</code></pre></div>
</div>
</pre></div>
```

![image](https://github.com/user-attachments/assets/727c5929-072d-45e5-b929-17a53b5f9167)
