### PR TITLE
docs: how to build this project's docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,37 @@ Anything contained within the _src_ folder is meant to be merged from the upstre
 
 There is no intention to support any mkdocs extensions in this theme because this theme is designed for the Sphinx documentation generator. You will often find that most of the extensions available for mkdocs are natively implemented in Sphinx or available in the form of a Sphinx extension.
 
+## Building this project's docs
+
+Install the following development tools:
+
+- [`uv` package manager](https://docs.astral.sh/uv/getting-started/installation/)
+- [Graphviz](https://graphviz.org/download/) (for generating graphs at docs' build-time)
+- [node.js](https://nodejs.org/en/download) (using [fnm](https://github.com/Schniz/fnm) is highly recommended)
+
+Setup the Python venv:
+
+```text
+uv sync
+```
+
+Assembling/copying over CSS/JS bundles and icons:
+
+```text
+npm install
+npm run build
+```
+
+Build documentation:
+
+```text
+uv run nox -s "docs(html)"
+```
+
+This sets up a Python venv (managed by `nox`), ensures necessary docs' (Python) dependencies are installed, and runs `sphinx-build`.
+
+If the last command completed successfully, the HTML docs can be browsed locally from the generated `docs/_build/html/index.html` file.
+
 ### Merging in changes from upstream
 
 There is a script titled "merge_from_mkdocs_material.py" that is designed to do most of the heavy lifting when pulling in changes from the mkdocs-material theme. It can only be executed in a Linux shell. More usage information is provided by the help menu:


### PR DESCRIPTION
See https://github.com/jbms/sphinx-immaterial/pull/478#issuecomment-3600397378

---

> Although, I would try to keep the instructions agnostic to any platform

I'm on Ubuntu 24.04 and ready to help with testing on it, but I'm afraid I'm not ready to help with other OSes

> BTW, --forcecolor is only used to add color to stdout for non-interactive terminal sessions.

Removed. I copy/pasted it from GitHub Actions

> instruction about necessary dev tools with links to their respective official install docs

There are many ways to install tools. My goal was to create something quick and practical, a fast path from cloning source code to having an index HTML file for testing, so you don't have to spend an hour on web searches for tooling you're not familiar with. As I mentioned before, I just want to update the dependency package https://github.com/jbms/sphinx-immaterial/pull/478#issue-3679464314, check it worked, and nothing is broken, no more, no less

> Also, please add info about node.js needed, but instead of hard-coding the node.js version in CONTRIBUTING.md, I'd recommend installing fnm or some tool that respects a .node-version file in project root (which would need to be added)

This is black magic for me. I can test it if you provide a baby steps guide :upside_down_face: 
