### PR TITLE
Substitute internal type names in constructor declaration

### DIFF
--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -2358,7 +2358,7 @@ def organize_entities(
                     "template <> " if template_parameters is not None else "",
                     location=(entity["location"]["file"], entity["location"]["line"]),
                 )
-            func_entity["declaration"] = declaration
+            func_entity["declaration"] = _substitute_internal_type_names(config, declaration)
         else:
             if replacements:
                 for key in cast(

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -2358,7 +2358,9 @@ def organize_entities(
                     "template <> " if template_parameters is not None else "",
                     location=(entity["location"]["file"], entity["location"]["line"]),
                 )
-            func_entity["declaration"] = _substitute_internal_type_names(config, declaration)
+            func_entity["declaration"] = _substitute_internal_type_names(
+                config, declaration
+            )
         else:
             if replacements:
                 for key in cast(


### PR DESCRIPTION
This is needed to rewrite types in constructors.  An alternative might be to rewrite the func_entity["declaration"] later.