### PR TITLE
feat(apidoc.cpp): conditionally add space between certain AST tokens

### DIFF
--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -962,7 +962,7 @@ def get_extent_spelling(translation_unit: TranslationUnit, extent: SourceRange) 
             else:
                 yield spelling
 
-    return " ".join(get_spellings())
+    return " ".join(get_spellings()).replace(" :: ", "::")
 
 
 def get_related_comments(decl: Cursor):

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -947,7 +947,10 @@ def get_extent_spelling(translation_unit: TranslationUnit, extent: SourceRange) 
         for token in translation_unit.get_tokens(extent=extent):
             if prev_token is not None:
                 yield prev_token.spelling
-                if prev_token.kind in add_space_between and token.kind in add_space_between:
+                if (
+                    prev_token.kind in add_space_between
+                    and token.kind in add_space_between
+                ):
                     yield " "
                 prev_token = None
             if token.kind == COMMENT:

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -950,7 +950,7 @@ def get_extent_spelling(translation_unit: TranslationUnit, extent: SourceRange) 
         for token in translation_unit.get_tokens(extent=extent):
             if prev_token is not None:
                 yield prev_token.spelling
-                 if tuple(prev_token.kind, token.kind) not in no_spaces:
+                if tuple(prev_token.kind, token.kind) not in no_spaces:
                     yield " "
                 prev_token = None
             if token.kind == COMMENT:

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -1540,9 +1540,6 @@ def _transform_unexposed_decl(config: Config, decl: Cursor) -> Optional[VarEntit
     # exposed as an unexposed decl.
 
     source_code = get_extent_spelling(decl.translation_unit, decl.extent)
-
-    # Note: Since `source_code` is reconstructed from the tokens, we don't need to
-    # worry about inconsistency in spacing.
     if not re.search(r"^\s*template\s*<", source_code):
         return None
 

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -939,10 +939,12 @@ def get_extent_spelling(translation_unit: TranslationUnit, extent: SourceRange) 
     whitespace.  This results in excessive whitespace, but that does not matter
     because this is intended to be parsed by the Sphinx cpp domain anyway.
     """
-    no_spaces = ((TokenKind.KEYWORD, TokenKind.PUNCTUATION),
-                 (TokenKind.IDENTIFIER, TokenKind.PUNCTUATION),
-                 (TokenKind.PUNCTUATION, TokenKind.KEYWORD),
-                 (TokenKind.PUNCTUATION, TokenKind.IDENTIFIER))
+    no_spaces = (
+        (TokenKind.KEYWORD, TokenKind.PUNCTUATION),
+        (TokenKind.IDENTIFIER, TokenKind.PUNCTUATION),
+        (TokenKind.PUNCTUATION, TokenKind.KEYWORD),
+        (TokenKind.PUNCTUATION, TokenKind.IDENTIFIER),
+    )
 
     def get_spellings():
         prev_token = None

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -2344,6 +2344,7 @@ def organize_entities(
         if _is_function(entity):
             func_entity = cast(FunctionEntity, entity)
             declaration = func_entity["declaration"]
+            declaration = _substitute_internal_type_names(config, declaration)
             if replacements:
                 declaration = _apply_identifier_replacements(declaration, replacements)
             if (

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -939,8 +939,10 @@ def get_extent_spelling(translation_unit: TranslationUnit, extent: SourceRange) 
     whitespace.  This results in excessive whitespace, but that does not matter
     because this is intended to be parsed by the Sphinx cpp domain anyway.
     """
-
-    add_space_between = (TokenKind.KEYWORD, TokenKind.IDENTIFIER, TokenKind.LITERAL)
+    no_spaces = (tuple(TokenKind.KEYWORD, TokenKind.PUNCTUATION),
+                 tuple(TokenKind.IDENTIFIER, TokenKind.PUNCTUATION),
+                 tuple(TokenKind.PUNCTUATION, TokenKind.KEYWORD),
+                 tuple(TokenKind.PUNCTUATION, TokenKind.IDENTIFIER))
 
     def get_spellings():
         prev_token = None
@@ -948,10 +950,7 @@ def get_extent_spelling(translation_unit: TranslationUnit, extent: SourceRange) 
         for token in translation_unit.get_tokens(extent=extent):
             if prev_token is not None:
                 yield prev_token.spelling
-                if (
-                    prev_token.kind in add_space_between
-                    and token.kind in add_space_between
-                ):
+                 if tuple(prev_token.kind, token.kind) not in no_spaces:
                     yield " "
                 prev_token = None
             if token.kind == COMMENT:

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -941,6 +941,7 @@ def get_extent_spelling(translation_unit: TranslationUnit, extent: SourceRange) 
     """
 
     add_space_between = (TokenKind.KEYWORD, TokenKind.IDENTIFIER, TokenKind.LITERAL)
+
     def get_spellings():
         prev_token = None
         COMMENT = TokenKind.COMMENT

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -940,20 +940,25 @@ def get_extent_spelling(translation_unit: TranslationUnit, extent: SourceRange) 
     because this is intended to be parsed by the Sphinx cpp domain anyway.
     """
 
+    add_space_between = (TokenKind.KEYWORD, TokenKind.IDENTIFIER, TokenKind.LITERAL)
     def get_spellings():
         prev_token = None
         COMMENT = TokenKind.COMMENT
         for token in translation_unit.get_tokens(extent=extent):
             if prev_token is not None:
                 yield prev_token.spelling
+                if prev_token.kind in add_space_between and token.kind in add_space_between:
+                    yield " "
                 prev_token = None
             if token.kind == COMMENT:
+                yield " "
                 continue
             prev_token = token
         # We need to handle the last token specially, because clang sometimes parses
         # ">>" as a single token but the extent may cover only the first of the two
         # angle brackets.
         if prev_token is not None:
+            yield " "
             spelling = prev_token.spelling
             token_end = cast(SourceLocation, prev_token.extent.end)
             offset_diff = token_end.offset - cast(SourceLocation, extent.end).offset
@@ -962,7 +967,7 @@ def get_extent_spelling(translation_unit: TranslationUnit, extent: SourceRange) 
             else:
                 yield spelling
 
-    return " ".join(get_spellings()).replace(" :: ", "::")
+    return "".join(get_spellings())
 
 
 def get_related_comments(decl: Cursor):

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -1544,7 +1544,7 @@ def _transform_unexposed_decl(config: Config, decl: Cursor) -> Optional[VarEntit
 
     # Note: Since `source_code` is reconstructed from the tokens, we don't need to
     # worry about inconsistency in spacing.
-    if not re.search("^\s*template\s*<", source_code):
+    if not re.search(r"^\s*template\s*<", source_code):
         return None
 
     # Assume that it is a variable template

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -1544,7 +1544,7 @@ def _transform_unexposed_decl(config: Config, decl: Cursor) -> Optional[VarEntit
 
     # Note: Since `source_code` is reconstructed from the tokens, we don't need to
     # worry about inconsistency in spacing.
-    if not source_code.startswith("template <"):
+    if not re.search("^\s*template\s*<", source_code):
         return None
 
     # Assume that it is a variable template

--- a/sphinx_immaterial/apidoc/cpp/api_parser.py
+++ b/sphinx_immaterial/apidoc/cpp/api_parser.py
@@ -939,10 +939,10 @@ def get_extent_spelling(translation_unit: TranslationUnit, extent: SourceRange) 
     whitespace.  This results in excessive whitespace, but that does not matter
     because this is intended to be parsed by the Sphinx cpp domain anyway.
     """
-    no_spaces = (tuple(TokenKind.KEYWORD, TokenKind.PUNCTUATION),
-                 tuple(TokenKind.IDENTIFIER, TokenKind.PUNCTUATION),
-                 tuple(TokenKind.PUNCTUATION, TokenKind.KEYWORD),
-                 tuple(TokenKind.PUNCTUATION, TokenKind.IDENTIFIER))
+    no_spaces = ((TokenKind.KEYWORD, TokenKind.PUNCTUATION),
+                 (TokenKind.IDENTIFIER, TokenKind.PUNCTUATION),
+                 (TokenKind.PUNCTUATION, TokenKind.KEYWORD),
+                 (TokenKind.PUNCTUATION, TokenKind.IDENTIFIER))
 
     def get_spellings():
         prev_token = None
@@ -950,7 +950,7 @@ def get_extent_spelling(translation_unit: TranslationUnit, extent: SourceRange) 
         for token in translation_unit.get_tokens(extent=extent):
             if prev_token is not None:
                 yield prev_token.spelling
-                if tuple(prev_token.kind, token.kind) not in no_spaces:
+                if (prev_token.kind, token.kind) not in no_spaces:
                     yield " "
                 prev_token = None
             if token.kind == COMMENT:

--- a/tests/cpp_api_parser_test.py
+++ b/tests/cpp_api_parser_test.py
@@ -325,4 +325,4 @@ class ClassWithSourceLocation {
     for x in output["entities"].values():
         d = x.get("declaration")
         if d:
-            assert d.find("source_location") != -1
+            assert cast(str, d).find("source_location") != -1

--- a/tests/cpp_api_parser_test.py
+++ b/tests/cpp_api_parser_test.py
@@ -306,7 +306,7 @@ void LogSourceLocation(foo::SourceLocation loc = Default());
 class ClassWithSourceLocation {
  public:
   /// Constructor.
-  ClassWithSourceLocation(foo::SourceLocation loc = Default()) 
+  ClassWithSourceLocation(foo::SourceLocation loc = Default())
     : loc_(loc) {}
 
   foo::SourceLocation loc_;

--- a/tests/cpp_api_parser_test.py
+++ b/tests/cpp_api_parser_test.py
@@ -296,14 +296,16 @@ namespace foo {
 struct SourceLocation {};
 }
 
-// Return type
+/// Default method
 foo::SourceLocation Default();
 
+/// Logging method
 void LogSourceLocation(foo::SourceLocation loc = Default());
 
+/// Class
 class ClassWithSourceLocation {
  public:
-  /// Constructs from a label.
+  /// Constructor.
   ClassWithSourceLocation(foo::SourceLocation loc = Default()) 
     : loc_(loc) {}
 
@@ -318,5 +320,9 @@ class ClassWithSourceLocation {
     output = api_parser.generate_output(config)
     assert not output.get("errors")
     print(output)
-    entities = list(output["entities"].values())
-    assert len(entities) == 2
+
+    assert len(output.get("entities", {}).values()) == 4
+    for x in output["entities"].values():
+        d = x.get("declaration")
+        if d:
+            assert d.find("source_location") != -1

--- a/tests/cpp_api_parser_test.py
+++ b/tests/cpp_api_parser_test.py
@@ -314,7 +314,7 @@ class ClassWithSourceLocation {
 """,
         type_replacements={
             "foo::SourceLocation": "source_location",
-      },    
+        },
     )
 
     output = api_parser.generate_output(config)

--- a/tests/cpp_api_parser_test.py
+++ b/tests/cpp_api_parser_test.py
@@ -284,3 +284,39 @@ constexpr inline bool HasA<int> = true;
         "HasA",
         "HasA-int",
     ]
+
+
+def test_type_replacements():
+    config = api_parser.Config(
+        input_path="a.cpp",
+        input_content=rb"""
+struct source_location {};
+
+namespace foo {
+struct SourceLocation {};
+}
+
+// Return type
+foo::SourceLocation Default();
+
+void LogSourceLocation(foo::SourceLocation loc = Default());
+
+class ClassWithSourceLocation {
+ public:
+  /// Constructs from a label.
+  ClassWithSourceLocation(foo::SourceLocation loc = Default()) 
+    : loc_(loc) {}
+
+  foo::SourceLocation loc_;
+};
+""",
+        type_replacements={
+            "foo::SourceLocation": "source_location",
+      },    
+    )
+
+    output = api_parser.generate_output(config)
+    assert not output.get("errors")
+    print(output)
+    entities = list(output["entities"].values())
+    assert len(entities) == 2


### PR DESCRIPTION
…rators.

Removing extra spaces around namespace separators is a simple fix to improve type matching when the result of get_extent_spelling() is passed to _substitute_internal_type_names()